### PR TITLE
bump versions to 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
         run: bash config.sh && ./gradlew build
       - name: Run cedar-java-hello-world
         working-directory: ./cedar-java-hello-world
-        run: ./gradlew run
+        run: ./gradlew test
 
   build_and_test_tiny_todo:
     name: tinytodo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,12 +64,13 @@ jobs:
         run: cargo fmt --all --check
       - name: cargo rustc
         working-directory: ./cedar-rust-hello-world
-        run: |
-             printf "\npath = \"../cedar/cedar-policy\"" >> Cargo.toml
-             RUSTFLAGS="-D warnings -F unsafe-code" cargo build --verbose
+        run: RUSTFLAGS="-D warnings -F unsafe-code" cargo build --verbose
       - name: cargo test
         working-directory: ./cedar-rust-hello-world
         run: cargo test --verbose
+      - name: cargo run
+        working-directory: ./cedar-rust-hello-world
+        run: cargo run --verbose
 
   build_and_test_java_hello_world:
     name: java-hello-world
@@ -99,6 +100,9 @@ jobs:
       - name: Build cedar-java-hello-world
         working-directory: ./cedar-java-hello-world
         run: bash config.sh && ./gradlew build
+      - name: Run cedar-java-hello-world
+        working-directory: ./cedar-java-hello-world
+        run: ./gradlew run
 
   build_and_test_tiny_todo:
     name: tinytodo
@@ -123,9 +127,7 @@ jobs:
         run: cargo fmt --all --check
       - name: cargo rustc
         working-directory: ./tinytodo
-        run: |
-             printf "\npath = \"../cedar/cedar-policy\"" >> Cargo.toml
-             RUSTFLAGS="-D warnings -F unsafe-code" cargo build --verbose
+        run: RUSTFLAGS="-D warnings -F unsafe-code" cargo build --verbose
       - name: cargo test
         working-directory: ./tinytodo
         run: cargo test --verbose

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
-## Cedar Examples
+# Cedar Examples
 
 This repository contains examples demonstrating the use of [Cedar](https://github.com/cedar-policy/cedar), a policy language for writing and enforcing authorization policies in your applications.  The following table summarizes relevant information about the applications. Please refer to the `README.md` files in the subfolders for details about how to build and run them.
 
 | Example      | Languages | Description |
 | ----------- | ----------- | ---------- |
 | [`tinytodo`][] | Rust, Python | A simple application for managing task lists that uses Cedar for authorization |
-| [`cedar-java-hello-world`][] | Java | A simple application demonstrating the usage of [Cedar Java APIs][] |
-| [`cedar-rust-hello-world`][] | Rust | A simple application demonstrating the usage of [Cedar Rust APIs][] |
-| [`cedar-example-use-cases`][]     |  Cedar  | Cedar policies of two applications demanding authorization services |
+| [`cedar-java-hello-world`][] | Java | A simple application demonstrating the usage of the [Cedar Java APIs][] |
+| [`cedar-rust-hello-world`][] | Rust | A simple application demonstrating the usage of the [Cedar Rust APIs][] |
+| [`cedar-policy-language-in-action`][] | Cedar | Cedar policies and schemas for the [Cedar policy language in action](https://catalog.workshops.aws/cedar-policy-language-in-action) workshop |
+| [`cedar-example-use-cases`][] |  Cedar  | Cedar policies and schemas for two example applications |
 
 ## Security
 
@@ -19,10 +20,8 @@ This project is licensed under the Apache-2.0 License.
 
 [Cedar Rust APIs]: https://github.com/cedar-policy/cedar/tree/main/cedar-policy
 [Cedar Java APIs]: https://github.com/cedar-policy/cedar-java
-[GitHub's authorization model in Cedar]: ./cedar-example-use-cases/github_example
 [`cedar-example-use-cases`]: ./cedar-example-use-cases
-[`cedar-github-model-app`]: ./cedar-github-model-app
 [`cedar-java-hello-world`]: ./cedar-java-hello-world
 [`cedar-rust-hello-world`]: ./cedar-rust-hello-world
+[`cedar-policy-language-in-action`]: ./cedar-policy-language-in-action
 [`tinytodo`]: ./tinytodo
-

--- a/cedar-example-use-cases/README.md
+++ b/cedar-example-use-cases/README.md
@@ -4,13 +4,16 @@ This repository contains Cedar policies that model the authorization logic of tw
 [Document cloud drive example](./document_cloud) models a cloud-based document sharing system, like Google Drive or Dropbox. [GitHub example](./github_example/) mimics GitHub's repository access permissions.
 
 ## Quick Start
+
 You can validate example policies and perform authorization requests using the [Cedar CLI](https://github.com/cedar-policy/cedar/tree/main/cedar-policy-cli).
+Simply build the CLI following the instructions in the README, and then add the resulting executable (`cedar`) to your path.
+This executable will end up in `/path/to/cedar-policy/cedar/target/debug/`.
 
 ```shell
 # validate the document_cloud policies
 cedar validate \
       --policies document_cloud/policies.cedar \
-      --schema document_cloud/schema.json
+      --schema document_cloud/document_cloud.cedarschema.json
 
 # perform an authorization request with the document_cloud policies
 cedar authorize \
@@ -19,13 +22,15 @@ cedar authorize \
       --request-json document_cloud/allow_requests/alice_view_alice_public.json
 ```
 
+Use the `run.sh` script to validate the policies and run every authorization test for both examples.
+
 ## Subfolder Organization
 
 | File  | Description |
 | ------------- | ------------- |
 | `policies.cedar`  | Cedar policies for authorization management  |
 | `entities.json`  | Example entity store  |
-| `schema.json` | Example schema |
+| `*.cedarschema.json` | Example schema |
 | `allow_requests` | Allowed requests |
 | `deny_requests` | Denied requests |
 | `README.md` | A tutorial walking through the example application |

--- a/cedar-java-hello-world/README.md
+++ b/cedar-java-hello-world/README.md
@@ -24,7 +24,7 @@ cd ../.. && bash config.sh && ./gradlew build
 ### Run
 
 ```shell
-./gradlew run
+./gradlew test
 ```
 
 ## Security

--- a/cedar-java-hello-world/README.md
+++ b/cedar-java-hello-world/README.md
@@ -1,9 +1,11 @@
 # Cedar Java Hello World
 
-This repository contains a simple hello world program written in Java, using Cedar. 
+This repository contains a simple hello world program written in Java, using Cedar.
 It shows how to use of the Cedar Java API to evaluate a simple policy. You can look at the gradle files to see how to build CedarJava in your own Java applications.
 
 ## Usage
+
+The Java example works with the version of Cedar available on Maven, which (at the time of writing) is v2.3.3.
 
 To build, you'll need CedarJava and CedarJavaFFI. You will need to ensure that CedarJava is able to find the dynamic library of Cedar. To do that, you need to ensure the environment variable `CEDAR_JAVA_FFI_LIB` gives the location of your `cedar_java_ffi` shared library. Typically this can be done by running:
 
@@ -12,14 +14,15 @@ bash config.sh
 ```
 
 ### Build
-- checkout [cedar-policy/cedar-java](https://github.com/cedar-policy/cedar-java) to `cedar-java`
 
 ```shell
+git clone -b release/2.3.x https://github.com/cedar-policy/cedar-java.git
 cd cedar-java/CedarJavaFFI && cargo build
-cd ../../cedar-java-hello-world && ./gradlew build
+cd ../.. && bash config.sh && ./gradlew build
 ```
 
 ### Run
+
 ```shell
 ./gradlew run
 ```

--- a/cedar-java-hello-world/build.gradle
+++ b/cedar-java-hello-world/build.gradle
@@ -95,7 +95,3 @@ test {
         exceptionFormat 'full'
     }
 }
-
-application {
-  mainClassName = 'samplelib.SampleRunner'
-}

--- a/cedar-policy-language-in-action/README.md
+++ b/cedar-policy-language-in-action/README.md
@@ -6,7 +6,7 @@ The challenge problems let you apply your knowledge to create the Cedar policies
 
 ## Automated testing
 
-This example includes a test script (`run.sh`) which uses the Cedar CLI to run test cases matching the problem requirements.
+This example includes a test script (`run.sh`) which uses the [Cedar CLI](https://github.com/cedar-policy/cedar/tree/main/cedar-policy-cli) to run test cases matching the problem requirements.
 
 1. It uses the `validate` command against the `.cedar` and `.cedarschema.json` files.
 1. It uses the `authorize` command runs against all `.json` files in `ALLOW` and `DENY` folders.

--- a/cedar-rust-hello-world/Cargo.toml
+++ b/cedar-rust-hello-world/Cargo.toml
@@ -2,11 +2,12 @@
 name = "cedar-rust-hello-world"
 edition = "2018"
 
-version = "2.0.0"
+version = "0.1.0"
 publish = false
 
 [dependencies]
 serde_json = "1.0"
 
 [dependencies.cedar-policy]
-version = "2.3.0"
+version = "3.0.0"
+path = "../cedar/cedar-policy"

--- a/cedar-rust-hello-world/README.md
+++ b/cedar-rust-hello-world/README.md
@@ -1,6 +1,6 @@
 # Cedar Rust Hello World
 
-This repository contains a simple hello world program demonstrating typical usage of the [Cedar Rust APIs](https://github.com/cedar-policy/cedar/tree/main/cedar-policy). 
+This repository contains a simple hello world program demonstrating typical usage of the [Cedar Rust APIs](https://github.com/cedar-policy/cedar/tree/main/cedar-policy).
 
 The file `src/main.rs` provides example code for the key steps an application takes to use Cedar. These include (1) parsing policies from text; (2) creating access requests and asking whether the request is authorized by the policies; (3) making requests that have an optional `context` (in addition to a principal, action, and resource); (4) providing _entities_ with a request, which are application data relevant to the request; and (5) validating that policies are consistent with a provided schema.
 
@@ -12,7 +12,10 @@ The following are functions that demonstrate elements of the above.
 * `entity_objects`: constructing entities from Rust objects
 * `validate`: validating a policy
 
-### Build and Run
+## Build and Run
+
+This example expects that the [`cedar`](https://github.com/cedar-policy/cedar) repository is cloned into the toplevel (`../cedar-examples`) directory.
+
 ```shell
 cargo run
 ```

--- a/cedar-rust-hello-world/src/main.rs
+++ b/cedar-rust-hello-world/src/main.rs
@@ -376,8 +376,7 @@ fn validate() {
                         "type": "Record",
                         "attributes": {
                             "age": {
-                                "type": "Long",
-                                "name": "age"
+                                "type": "Long"
                             }
                         }
                     },

--- a/tinytodo/Cargo.toml
+++ b/tinytodo/Cargo.toml
@@ -18,5 +18,5 @@ lazy_static = "1.4.0"
 notify = { version = "5.1.0", default-features = false, features = ["macos_kqueue"] }
 
 [dependencies.cedar-policy]
-version = "2.3.0"
-#path = "../../cedar/cedar-policy"
+version = "3.0.0"
+path = "../cedar/cedar-policy"

--- a/tinytodo/README.md
+++ b/tinytodo/README.md
@@ -10,25 +10,33 @@ The code is structured as a server, written in Rust, that processes HTTP command
 
 ### Build
 
-You need Python3 and Rust. Rust can be installed via (rustup)[https://rustup.rs]. Python3 can be installed (here)[https://www.python.org/] or using your system's package manager.
+You need Python3 and Rust. Rust can be installed via [rustup](https://rustup.rs). Python3 can be installed [here](https://www.python.org/) or using your system's package manager.
 
-Install the needed python packages, and build the server as follows. 
+This example expects that the [`cedar`](https://github.com/cedar-policy/cedar) repository is cloned into the toplevel (`../cedar-examples`) directory.
+
+Install the needed python packages, and build the server as follows.
+
 ```shell
 pip3 install -r requirements.txt
 cargo build --release
 ```
+
 The Rust executable is stored in `target/release/tiny-todo-server`.
 
 ### Run
 
 To start the client within Python interactive mode, enter
+
 ```shell
 python3 -i ./tinytodo.py
 ```
+
 To start the server, from the Python primary prompt `>>>` enter
+
 ```python
 start_server()
 ```
+
 When it starts up, the server reads in the Cedar policies in `policies.cedar`, and the Cedar entities, which define the TinyTodo `User`s and `Team`s, from `entities.json`. It validates the policies are consistent with `tinytodo.cedarschema.json`, and will abort if they are not.
 
 Client code `tinytodo.py` defines the functions you can call, which serve as the list of commands. See also [`TUTORIAL.md`](./TUTORIAL.md) for a detailed description of how to use these commands, and how TinyTodo works. Here is a brief description of the commands:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR fixes the CI break caused by [cedar#334](https://github.com/cedar-policy/cedar/pull/334), as well as several other minor things I noticed when checking that I was able to follow build instructions locally. Whitespace changes are due to auto-formatting.

**Note:** I expect to followup soon with a PR to create a `release/2.x` branch, per #60. That PR will undo some of these changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
