### PR TITLE
CI fixes, part 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,21 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  get-branch-name:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get branch name
+        shell: bash
+        # The workflow is triggered by pull_request so we use `GITHUB_BASE_REF`
+        run: echo "branch_name=${GITHUB_BASE_REF}" >> $GITHUB_OUTPUT
+        id: get_branch_name
+    outputs:
+      branch_name: ${{ steps.get_branch_name.outputs.branch_name }}
+
   run_example_use_cases:
     name: example-use-cases
     runs-on: ubuntu-latest
+    needs: get-branch-name
     strategy:
       matrix:
         toolchain:
@@ -21,7 +33,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: cedar-policy/cedar
-          ref: main
+          ref: ${{ needs.get-branch-name.outputs.branch_name }}
           path: ./cedar
       - name: rustup
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
@@ -44,6 +56,7 @@ jobs:
   build_and_test_rust_hello_world:
     name: rust-hello-world
     runs-on: ubuntu-latest
+    needs: get-branch-name
     strategy:
       matrix:
         toolchain:
@@ -55,7 +68,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: cedar-policy/cedar
-          ref: main
+          ref: ${{ needs.get-branch-name.outputs.branch_name }}
           path: ./cedar
       - name: rustup
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
@@ -92,7 +105,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: cedar-policy/cedar-java
-          ref: release/2.3.x
+          ref: release/2.3.x # Java example currently only builds for 2.3.3
           path: ./cedar-java-hello-world/cedar-java
       - name: rustup
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
@@ -109,6 +122,7 @@ jobs:
   build_and_test_tiny_todo:
     name: tinytodo
     runs-on: ubuntu-latest
+    needs: get-branch-name
     strategy:
       matrix:
         toolchain:
@@ -120,7 +134,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: cedar-policy/cedar
-          ref: main
+          ref: ${{ needs.get-branch-name.outputs.branch_name }}
           path: ./cedar
       - name: rustup
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Update the CI to use the current branch name to decide what version of `cedar` to use, following the example in https://github.com/cedar-policy/cedar/blob/main/.github/workflows/build_downstream_deps.yml. This should make it simple to create new `release/x.x.x` branches in this repository.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
