### PR TITLE
set up 2.4.x release branch

### DIFF
--- a/cedar-rust-hello-world/Cargo.toml
+++ b/cedar-rust-hello-world/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 serde_json = "1.0"
 
 [dependencies.cedar-policy]
-version = "3.0.0"
+version = "2.4"

--- a/cedar-rust-hello-world/README.md
+++ b/cedar-rust-hello-world/README.md
@@ -14,8 +14,6 @@ The following are functions that demonstrate elements of the above.
 
 ## Build and Run
 
-This example expects that the [`cedar`](https://github.com/cedar-policy/cedar) repository is cloned into the toplevel (`../cedar-examples`) directory. You can instruct Cargo to use your local version of `cedar-policy` by adding `path = "../cedar/cedar-policy"` to Cargo.toml.
-
 ```shell
 cargo run
 ```

--- a/cedar-rust-hello-world/src/main.rs
+++ b/cedar-rust-hello-world/src/main.rs
@@ -136,7 +136,7 @@ fn entity_json() {
         "iam_idc".to_string(),
         RestrictedExpression::from_str(&t1.to_string()).unwrap(),
     );
-    let c = Context::from_pairs(context2).expect("no duplicate keys!");
+    let c = Context::from_pairs(context2);
 
     let request: Request = Request::new(Some(p), Some(a), Some(r), c);
 

--- a/tinytodo/Cargo.toml
+++ b/tinytodo/Cargo.toml
@@ -18,4 +18,4 @@ lazy_static = "1.4.0"
 notify = { version = "5.1.0", default-features = false, features = ["macos_kqueue"] }
 
 [dependencies.cedar-policy]
-version = "3.0.0"
+version = "2.4"

--- a/tinytodo/README.md
+++ b/tinytodo/README.md
@@ -12,8 +12,6 @@ The code is structured as a server, written in Rust, that processes HTTP command
 
 You need Python3 and Rust. Rust can be installed via [rustup](https://rustup.rs). Python3 can be installed [here](https://www.python.org/) or using your system's package manager.
 
-This example expects that the [`cedar`](https://github.com/cedar-policy/cedar) repository is cloned into the toplevel (`../cedar-examples`) directory. You can instruct Cargo to use your local version of `cedar-policy` by adding `path = "../cedar/cedar-policy"` to Cargo.toml.
-
 Install the needed python packages, and build the server as follows.
 
 ```shell

--- a/tinytodo/src/objects.rs
+++ b/tinytodo/src/objects.rs
@@ -322,7 +322,7 @@ impl From<Task> for RestrictedExpression {
         ]
         .into_iter()
         .map(|(x, v)| (x.to_string(), v));
-        RestrictedExpression::new_record(fields).expect("no duplicate keys!")
+        RestrictedExpression::new_record(fields)
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Set up a `release/2.4.x` branch. As discussed offline, this could just as well be `release/2.x` since the examples should be consistent with any 2.x version, but it makes the CI a little easier to have the branch names match between `cedar` and `cedar-spec`.

_Note:_ This was originally #66, which I unintentionally closed by pushing directly to the the release branch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
