### PR TITLE
Update for `is` operator

### DIFF
--- a/cedar-rust-hello-world/src/main.rs
+++ b/cedar-rust-hello-world/src/main.rs
@@ -15,7 +15,7 @@
  */
 
 #![forbid(unsafe_code)]
-use cedar_policy::PrincipalConstraint::{Any, Eq, In};
+use cedar_policy::PrincipalConstraint::{Any, Eq, In, Is, IsIn};
 use cedar_policy::{
     Authorizer, Context, Decision, Entities, Entity, EntityId, EntityTypeName, EntityUid, Policy,
     PolicyId, PolicySet, Request, Response, RestrictedExpression, Schema, SlotId, Template,
@@ -69,6 +69,8 @@ fn parse_policy() {
                     Any => println!("No Principal"),
                     In(euid) => println!("Principal Constraint: Principal in {}", euid),
                     Eq(euid) => println!("Principal Constraint: Principal=={}", euid),
+                    Is(entity_type) => println!("Principal Constraint: Principal is {}", entity_type),
+                    IsIn(entity_type, euid) => println!("Principal Constraint: Principal is {} in {}", entity_type, euid),
                 }
             }
         }

--- a/cedar-rust-hello-world/src/main.rs
+++ b/cedar-rust-hello-world/src/main.rs
@@ -101,7 +101,7 @@ fn json_context() {
 
     let (p, a, r) = create_p_a_r();
     // create a request
-    let request: Request = Request::new(Some(p), Some(a), Some(r), c);
+    let request: Request = Request::new(Some(p), Some(a), Some(r), c, None).unwrap();
 
     // create a policy
     let s = r#"permit(
@@ -145,7 +145,7 @@ fn entity_json() {
     );
     let c = Context::from_pairs(context2).expect("no duplicate keys!");
 
-    let request: Request = Request::new(Some(p), Some(a), Some(r), c);
+    let request: Request = Request::new(Some(p), Some(a), Some(r), c, None).unwrap();
 
     // create a policy
     let s = "
@@ -189,7 +189,7 @@ fn entity_objects() {
     );
 
     let c = Context::empty();
-    let request: Request = Request::new(Some(p), Some(a), Some(r), c);
+    let request: Request = Request::new(Some(p), Some(a), Some(r), c, None).unwrap();
 
     // create a policy
     let c1 = "permit(
@@ -449,7 +449,7 @@ fn annotate() {
 
     let policies = PolicySet::from_str(src).unwrap();
     let (p, a, r) = create_p_a_r();
-    let request: Request = Request::new(Some(p), Some(a), Some(r), Context::empty());
+    let request: Request = Request::new(Some(p), Some(a), Some(r), Context::empty(), None).unwrap();
     let ans = execute_query(&request, &policies, Entities::empty());
     for reason in ans.diagnostics().reason() {
         //print all the annotations

--- a/cedar-rust-hello-world/src/main.rs
+++ b/cedar-rust-hello-world/src/main.rs
@@ -69,8 +69,13 @@ fn parse_policy() {
                     Any => println!("No Principal"),
                     In(euid) => println!("Principal Constraint: Principal in {}", euid),
                     Eq(euid) => println!("Principal Constraint: Principal=={}", euid),
-                    Is(entity_type) => println!("Principal Constraint: Principal is {}", entity_type),
-                    IsIn(entity_type, euid) => println!("Principal Constraint: Principal is {} in {}", entity_type, euid),
+                    Is(entity_type) => {
+                        println!("Principal Constraint: Principal is {}", entity_type)
+                    }
+                    IsIn(entity_type, euid) => println!(
+                        "Principal Constraint: Principal is {} in {}",
+                        entity_type, euid
+                    ),
                 }
             }
         }

--- a/tinytodo/policies.cedar
+++ b/tinytodo/policies.cedar
@@ -7,7 +7,7 @@ permit (
 
 // Policy 1: A User can perform any action on a List they own
 permit (principal, action, resource)
-when { resource has owner && resource.owner == principal };
+when { resource is List && resource.owner == principal };
 
 // Policy 2: A User can see a List if they are either a reader or editor
 permit (

--- a/tinytodo/src/context.rs
+++ b/tinytodo/src/context.rs
@@ -405,7 +405,7 @@ impl AppContext {
             Some(action.as_ref().clone().into()),
             Some(resource.as_ref().clone().into()),
             Context::empty(),
-            None,
+            Some(&self.schema),
         )
         .map_err(|e| Error::Request(e.to_string()))?;
         info!(

--- a/tinytodo/src/context.rs
+++ b/tinytodo/src/context.rs
@@ -168,6 +168,8 @@ pub enum Error {
     IO(#[from] std::io::Error),
     #[error("Error Parsing PolicySet: {0}")]
     Policy(#[from] ParseErrors),
+    #[error("Error constructing authorization request: {0}")]
+    Request(String),
 }
 
 impl Error {
@@ -403,7 +405,9 @@ impl AppContext {
             Some(action.as_ref().clone().into()),
             Some(resource.as_ref().clone().into()),
             Context::empty(),
-        );
+            None,
+        )
+        .map_err(|e| Error::Request(e.to_string()))?;
         info!(
             "is_authorized request: principal: {}, action: {}, resource: {}",
             principal.as_ref(),


### PR DESCRIPTION
Changes after https://github.com/cedar-policy/cedar/pull/396

* Fix `match` on policy scope
* Use `is` instead of `has` in TinyTodo
