### PR TITLE
TinyTodo: Fix schema for User entities

### DIFF
--- a/tinytodo/tinytodo.cedarschema.json
+++ b/tinytodo/tinytodo.cedarschema.json
@@ -6,15 +6,7 @@
 				"memberOfTypes": [
 					"Team",
 					"Application"
-				],
-				"shape": {
-					"type": "Record",
-					"attributes": {
-						"name": {
-							"type": "String"
-						}
-					}
-				}
+				]
 			},
 			"Team": {
 				"memberOfTypes": [


### PR DESCRIPTION
The schema requires that User entities have a `name`, but none of the users in the entity have this attribute, and it is not used in any policies.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
