### PR TITLE
Pull from GH while 3.0 is unreleased

### DIFF
--- a/tinytodo/Cargo.toml
+++ b/tinytodo/Cargo.toml
@@ -19,3 +19,5 @@ notify = { version = "5.1.0", default-features = false, features = ["macos_kqueu
 
 [dependencies.cedar-policy]
 version = "3.0.0"
+git = "https://github.com/cedar-policy/cedar"
+branch = "main"


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
tinytodo build was broken as it was set to use 3.0 and adjusted to use our new APIs. 
3.0 isn't on crates yet, so this failed. 
Setting to use the GH repo until 3.0 is published.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
