### PR TITLE
name policies by @id() annotation

### DIFF
--- a/tinytodo/policies.cedar
+++ b/tinytodo/policies.cedar
@@ -30,10 +30,11 @@ permit (
 when { principal in resource.editors };
 
 // Policy 4: Admins can perform any action on any resource
+// @id("admin-omnipotence")
 // permit (
-//     principal in Team::"admin",
-//     action,
-//     resource in Application::"TinyTodo"
+//    principal in Team::"admin",
+//    action,
+//    resource in Application::"TinyTodo"
 // );
 // 
 // Policy 5: Interns may not create new task lists

--- a/tinytodo/src/context.rs
+++ b/tinytodo/src/context.rs
@@ -20,8 +20,8 @@ use std::path::PathBuf;
 use tracing::{info, trace};
 
 use cedar_policy::{
-    Authorizer, Context, Decision, Diagnostics, EntityTypeName, ParseErrors, PolicySet, Request,
-    Schema, SchemaError, ValidationMode, Validator, PolicySetError
+    Authorizer, Context, Decision, Diagnostics, EntityTypeName, ParseErrors, PolicySet,
+    PolicySetError, Request, Schema, SchemaError, ValidationMode, Validator,
 };
 use thiserror::Error;
 use tokio::sync::{
@@ -228,14 +228,14 @@ enum ReadError {
     #[error("{0}")]
     Parse(#[from] ParseErrors),
     #[error("{0}")]
-    Semantics(#[from] PolicySetError)
+    Semantics(#[from] PolicySetError),
 }
 
 impl From<ReadError> for ContextError {
     fn from(error: ReadError) -> Self {
         match error {
             ReadError::Parse(e) => ContextError::Policy(e),
-            ReadError::Semantics(e) => ContextError::PolicySet(e)
+            ReadError::Semantics(e) => ContextError::PolicySet(e),
         }
     }
 }
@@ -244,7 +244,7 @@ impl From<ReadError> for Error {
     fn from(error: ReadError) -> Self {
         match error {
             ReadError::Parse(e) => Error::Policy(e),
-            ReadError::Semantics(e) => Error::PolicySet(e)
+            ReadError::Semantics(e) => Error::PolicySet(e),
         }
     }
 }
@@ -254,7 +254,7 @@ impl From<ReadError> for Error {
 /// This will rename template-linked policies to the id of their template, which may
 /// cause id conflicts, so only call this function before linking
 /// templates into the policy set.
-fn rename_from_id_annotation(ps: PolicySet) -> std::result::Result<PolicySet,ReadError> {
+fn rename_from_id_annotation(ps: PolicySet) -> std::result::Result<PolicySet, ReadError> {
     let mut new_ps = PolicySet::new();
     let t_iter = ps.templates().map(|t| match t.annotation("id") {
         None => Ok(t.clone()),


### PR DESCRIPTION
*Description of changes:* Updated TinyTodo so that policies can be optionally named using the `@id()` annotation, in the same way as the Cedar CLI.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
