### PR TITLE
Make TinyTodo CI default to crates.io not github

### DIFF
--- a/tinytodo/Cargo.toml
+++ b/tinytodo/Cargo.toml
@@ -19,5 +19,3 @@ notify = { version = "5.1.0", default-features = false, features = ["macos_kqueu
 
 [dependencies.cedar-policy]
 version = "3.0.0"
-git = "https://github.com/cedar-policy/cedar"
-branch = "main"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Make TinyTodo CI default to crates.io not github

Without this, changes like https://github.com/cedar-policy/cedar/pull/512 can accidentally break TinyTodo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
