### PR TITLE
Remove `version` from toml in CI Script

### DIFF
--- a/.github/workflows/build_tiny_todo_reusable.yml
+++ b/.github/workflows/build_tiny_todo_reusable.yml
@@ -31,6 +31,11 @@ jobs:
           ref: ${{ inputs.cedar_policy_ref }}
           path: ./cedar
 # If we passed a branch for cedar-policy, modify Cargo.toml to use that branch
+# First remove the `version` directive
+      - name: Replace Crates dot IO with Github version
+        if: "${{ inputs.cedar_policy_ref != '' }}"
+        run: cd tinytodo && head Cargo.toml -n $(echo $[$(wc -l Cargo.toml | awk '{ print $1 }') - 1]) > Cargo.temp && cp Cargo.temp Cargo.toml
+# Then add the `git` and `branch` directive
       - name: Replace Crates dot IO with Github version
         if: "${{ inputs.cedar_policy_ref != '' }}"
         run: cd tinytodo && printf "\n[patch.crates-io]\ncedar-policy = { git = 'https://github.com/cedar-policy/cedar.git', branch = '${{ inputs.cedar_policy_ref }}'}" >> Cargo.toml


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
When the CI wants to pull a git version, we need to drop the `version` flag from the toml

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
