### PR TITLE
Fix tinytodo build

### DIFF
--- a/.github/workflows/build_tiny_todo_reusable.yml
+++ b/.github/workflows/build_tiny_todo_reusable.yml
@@ -30,6 +30,8 @@ jobs:
           repository: cedar-policy/cedar
           ref: ${{ inputs.cedar_policy_ref }}
           path: ./cedar
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
 # If we passed a branch for cedar-policy, modify Cargo.toml to use that branch
       - name: Replace main with Specified Branch
         if: "${{ inputs.cedar_policy_ref != '' }}"

--- a/.github/workflows/build_tiny_todo_reusable.yml
+++ b/.github/workflows/build_tiny_todo_reusable.yml
@@ -33,7 +33,7 @@ jobs:
 # If we passed a branch for cedar-policy, modify Cargo.toml to use that branch
       - name: Replace Crates dot IO with Github version
         if: "${{ inputs.cedar_policy_ref != '' }}"
-        run: cd tinytodo && printf "\n[patch.crates-io]\ncedar-policy = { git = 'https://github.com/cedar-policy/cedar.git', branch = '${{ inputs.cedar_policy_ref }}'}" >> Cargo.toml
+        run: cd tinytodo && head -n -2 Cargo.toml > Temp.toml ; mv Temp.toml Cargo.toml && printf 'branch = "${{ inputs.cedar_policy_ref }}"\n' >> Cargo.toml
       - name: rustup
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - name: cargo fmt

--- a/.github/workflows/build_tiny_todo_reusable.yml
+++ b/.github/workflows/build_tiny_todo_reusable.yml
@@ -31,9 +31,9 @@ jobs:
           ref: ${{ inputs.cedar_policy_ref }}
           path: ./cedar
 # If we passed a branch for cedar-policy, modify Cargo.toml to use that branch
-      - name: Replace Crates dot IO with Github version
+      - name: Replace main with Specified Branch
         if: "${{ inputs.cedar_policy_ref != '' }}"
-        run: cd tinytodo && head -n -2 Cargo.toml > Temp.toml ; mv Temp.toml Cargo.toml && printf 'branch = "${{ inputs.cedar_policy_ref }}"\n' >> Cargo.toml
+        run: cd tinytodo && head -n -2 Cargo.toml > Temp.toml && mv Temp.toml Cargo.toml && printf 'branch = "${{ inputs.cedar_policy_ref }}"' >> Cargo.toml
       - name: rustup
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - name: cargo fmt

--- a/.github/workflows/build_tiny_todo_reusable.yml
+++ b/.github/workflows/build_tiny_todo_reusable.yml
@@ -30,8 +30,6 @@ jobs:
           repository: cedar-policy/cedar
           ref: ${{ inputs.cedar_policy_ref }}
           path: ./cedar
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
 # If we passed a branch for cedar-policy, modify Cargo.toml to use that branch
       - name: Replace main with Specified Branch
         if: "${{ inputs.cedar_policy_ref != '' }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,4 +128,4 @@ jobs:
     uses: ./.github/workflows/build_tiny_todo_reusable.yml
     with:
       cedar_policy_ref: "main" # use the latest commit on main
-      cedar_exaples_ref: "${{ github.head_ref }}"
+      cedar_examples_ref: "${{ github.head_ref }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,3 +128,4 @@ jobs:
     uses: ./.github/workflows/build_tiny_todo_reusable.yml
     with:
       cedar_policy_ref: "main" # use the latest commit on main
+      cedar_exaples_ref: "${{ github.head_ref }}"

--- a/tinytodo/Cargo.toml
+++ b/tinytodo/Cargo.toml
@@ -19,8 +19,6 @@ notify = { version = "5.1.0", default-features = false, features = ["macos_kqueu
 
 [dependencies.cedar-policy]
 version = "3.0.0"
-git = "https://github.com/cedar-policy/cedar"
-branch = "main"
 
 [features]
 use-templates = []

--- a/tinytodo/Cargo.toml
+++ b/tinytodo/Cargo.toml
@@ -17,10 +17,11 @@ tracing-subscriber = "0.3.17"
 lazy_static = "1.4.0"
 notify = { version = "5.1.0", default-features = false, features = ["macos_kqueue"] }
 
+[features]
+use-templates = []
+
 [dependencies.cedar-policy]
 version = "3.0.0"
 git = "https://github.com/cedar-policy/cedar"
 branch = "main"
-
-[features]
-use-templates = []
+#Do not add any lines below this. CI relies on the previous line being the second-to-last line in the file

--- a/tinytodo/Cargo.toml
+++ b/tinytodo/Cargo.toml
@@ -19,6 +19,8 @@ notify = { version = "5.1.0", default-features = false, features = ["macos_kqueu
 
 [dependencies.cedar-policy]
 version = "3.0.0"
+git = "https://github.com/cedar-policy/cedar"
+branch = "main"
 
 [features]
 use-templates = []

--- a/tinytodo/README.md
+++ b/tinytodo/README.md
@@ -18,7 +18,7 @@ Install the needed python packages, and build the server as follows.
 
 ```shell
 pip3 install -r requirements.txt
-cargo build --release --config 'patch.crates-io.cedar-policy.git="https://github.com/cedar-policy/cedar"'
+cargo build --release
 ```
 
 The Rust executable is stored in `target/release/tiny-todo-server`.

--- a/tinytodo/README.md
+++ b/tinytodo/README.md
@@ -18,7 +18,7 @@ Install the needed python packages, and build the server as follows.
 
 ```shell
 pip3 install -r requirements.txt
-cargo build --release
+cargo build --release --config 'patch.crates-io.cedar-policy.git="https://github.com/cedar-policy/cedar"'
 ```
 
 The Rust executable is stored in `target/release/tiny-todo-server`.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
https://github.com/cedar-policy/cedar-examples/pull/82 hard-coded the TinyTodo build to use the latest commit on cedar-policy's `main` branch. We don't want that because we'd like to see if a new commit we're considering adding to `main` breaks TinyTodo.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
