### PR TITLE
Use `rev` instead of `branch` to fix CI for builds from forks

### DIFF
--- a/.github/workflows/build_rust_hello_world_reusable.yml
+++ b/.github/workflows/build_rust_hello_world_reusable.yml
@@ -27,7 +27,7 @@ jobs:
 # If we passed a branch for cedar-policy, modify Cargo.toml to use that branch
       - name: Replace Crates dot IO with Github version
         if: "${{ inputs.cedar_policy_ref != '' }}"
-        run: cd cedar-rust-hello-world && printf "\n[patch.crates-io]\ncedar-policy = { git = 'https://github.com/cedar-policy/cedar.git', ref = '${{ inputs.cedar_policy_ref }}'}" >> Cargo.toml
+        run: cd cedar-rust-hello-world && printf "\n[patch.crates-io]\ncedar-policy = { git = 'https://github.com/cedar-policy/cedar.git', rev = '${{ inputs.cedar_policy_ref }}'}" >> Cargo.toml
       - name: rustup
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - name: cargo fmt

--- a/.github/workflows/build_rust_hello_world_reusable.yml
+++ b/.github/workflows/build_rust_hello_world_reusable.yml
@@ -27,7 +27,7 @@ jobs:
 # If we passed a branch for cedar-policy, modify Cargo.toml to use that branch
       - name: Replace Crates dot IO with Github version
         if: "${{ inputs.cedar_policy_ref != '' }}"
-        run: cd cedar-rust-hello-world && printf "\n[patch.crates-io]\ncedar-policy = { git = 'https://github.com/cedar-policy/cedar.git', branch = '${{ inputs.cedar_policy_ref }}'}" >> Cargo.toml
+        run: cd cedar-rust-hello-world && printf "\n[patch.crates-io]\ncedar-policy = { git = 'https://github.com/cedar-policy/cedar.git', ref = '${{ inputs.cedar_policy_ref }}'}" >> Cargo.toml
       - name: rustup
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - name: cargo fmt

--- a/.github/workflows/build_tiny_todo_reusable.yml
+++ b/.github/workflows/build_tiny_todo_reusable.yml
@@ -33,7 +33,7 @@ jobs:
 # If we passed a branch for cedar-policy, modify Cargo.toml to use that branch
       - name: Replace main with Specified Branch
         if: "${{ inputs.cedar_policy_ref != '' }}"
-        run: cd tinytodo && head -n -2 Cargo.toml > Temp.toml && mv Temp.toml Cargo.toml && printf 'ref = "${{ inputs.cedar_policy_ref }}"' >> Cargo.toml
+        run: cd tinytodo && head -n -2 Cargo.toml > Temp.toml && mv Temp.toml Cargo.toml && printf 'rev = "${{ inputs.cedar_policy_ref }}"' >> Cargo.toml
       - name: rustup
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - name: cargo fmt

--- a/.github/workflows/build_tiny_todo_reusable.yml
+++ b/.github/workflows/build_tiny_todo_reusable.yml
@@ -33,7 +33,7 @@ jobs:
 # If we passed a branch for cedar-policy, modify Cargo.toml to use that branch
       - name: Replace main with Specified Branch
         if: "${{ inputs.cedar_policy_ref != '' }}"
-        run: cd tinytodo && head -n -2 Cargo.toml > Temp.toml && mv Temp.toml Cargo.toml && printf 'branch = "${{ inputs.cedar_policy_ref }}"' >> Cargo.toml
+        run: cd tinytodo && head -n -2 Cargo.toml > Temp.toml && mv Temp.toml Cargo.toml && printf 'ref = "${{ inputs.cedar_policy_ref }}"' >> Cargo.toml
       - name: rustup
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - name: cargo fmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
     needs: get-branch-name
     uses: ./.github/workflows/run_example_use_cases_reusable.yml
     with:
-      cedar_policy_ref: "refs/head/main" # use the latest commit on main
+      cedar_policy_ref: "refs/heads/main" # use the latest commit on main
       cedar_examples_ref: "${{ github.head_ref }}" # use the current PR's commit
 
   build_rust_hello_world:
@@ -64,7 +64,7 @@ jobs:
     needs: get-branch-name
     uses: ./.github/workflows/build_rust_hello_world_reusable.yml
     with:
-      cedar_policy_ref: "refs/head/main" # use the latest commit on main
+      cedar_policy_ref: "refs/heads/main" # use the latest commit on main
       cedar_examples_ref: "${{ github.head_ref }}" # use the current PR's commit
 
   build_tiny_todo:
@@ -72,5 +72,5 @@ jobs:
     needs: get-branch-name
     uses: ./.github/workflows/build_tiny_todo_reusable.yml
     with:
-      cedar_policy_ref: "refs/head/main" # use the latest commit on main
+      cedar_policy_ref: "refs/heads/main" # use the latest commit on main
       cedar_examples_ref: "${{ github.head_ref }}" # use the current PR's commit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     uses: ./.github/workflows/run_example_use_cases_reusable.yml
     with:
       cedar_policy_ref: "main" # use the latest commit on main
-      cedar_examples_ref: "${{ github.head_ref }}" # use the current PR's commit
+      cedar_examples_ref: "${{ github.ref }}" # use the current PR's commit
 
   build_rust_hello_world:
     name: rust_hello_world
@@ -65,7 +65,7 @@ jobs:
     uses: ./.github/workflows/build_rust_hello_world_reusable.yml
     with:
       cedar_policy_ref: "main" # use the latest commit on main
-      cedar_examples_ref: "${{ github.head_ref }}" # use the current PR's commit
+      cedar_examples_ref: "${{ github.ref }}" # use the current PR's commit
 
   build_tiny_todo:
     name: tinytodo
@@ -73,4 +73,4 @@ jobs:
     uses: ./.github/workflows/build_tiny_todo_reusable.yml
     with:
       cedar_policy_ref: "main" # use the latest commit on main
-      cedar_examples_ref: "${{ github.head_ref }}" # use the current PR's commit
+      cedar_examples_ref: "${{ github.ref }}" # use the current PR's commit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
     needs: get-branch-name
     uses: ./.github/workflows/run_example_use_cases_reusable.yml
     with:
-      cedar_policy_ref: "main" # use the latest commit on main
+      cedar_policy_ref: "refs/head/main" # use the latest commit on main
       cedar_examples_ref: "${{ github.head_ref }}" # use the current PR's commit
 
   build_rust_hello_world:
@@ -64,7 +64,7 @@ jobs:
     needs: get-branch-name
     uses: ./.github/workflows/build_rust_hello_world_reusable.yml
     with:
-      cedar_policy_ref: "main" # use the latest commit on main
+      cedar_policy_ref: "refs/head/main" # use the latest commit on main
       cedar_examples_ref: "${{ github.head_ref }}" # use the current PR's commit
 
   build_tiny_todo:
@@ -72,5 +72,5 @@ jobs:
     needs: get-branch-name
     uses: ./.github/workflows/build_tiny_todo_reusable.yml
     with:
-      cedar_policy_ref: "main" # use the latest commit on main
+      cedar_policy_ref: "refs/head/main" # use the latest commit on main
       cedar_examples_ref: "${{ github.head_ref }}" # use the current PR's commit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     uses: ./.github/workflows/run_example_use_cases_reusable.yml
     with:
       cedar_policy_ref: "main" # use the latest commit on main
-      cedar_examples_ref: "${{ github.ref }}" # use the current PR's commit
+      cedar_examples_ref: "${{ github.head_ref }}" # use the current PR's commit
 
   build_rust_hello_world:
     name: rust_hello_world
@@ -65,7 +65,7 @@ jobs:
     uses: ./.github/workflows/build_rust_hello_world_reusable.yml
     with:
       cedar_policy_ref: "main" # use the latest commit on main
-      cedar_examples_ref: "${{ github.ref }}" # use the current PR's commit
+      cedar_examples_ref: "${{ github.head_ref }}" # use the current PR's commit
 
   build_tiny_todo:
     name: tinytodo
@@ -73,4 +73,4 @@ jobs:
     uses: ./.github/workflows/build_tiny_todo_reusable.yml
     with:
       cedar_policy_ref: "main" # use the latest commit on main
-      cedar_examples_ref: "${{ github.ref }}" # use the current PR's commit
+      cedar_examples_ref: "${{ github.head_ref }}" # use the current PR's commit


### PR DESCRIPTION

Branches from forks can't be referenced by name, but github make a ref available at `github.ref` in the CI YAML for all pull requests (e.g., `refs/pull/123/merge`). Referencing this in `branch` doesn't work so we have to change to `rev`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
