### PR TITLE
Tweak logger setup

### DIFF
--- a/tinytodo/Cargo.toml
+++ b/tinytodo/Cargo.toml
@@ -13,7 +13,7 @@ uuid = { version = "1.3.0", features = ["v4", "fast-rng", "macro-diagnostics"] }
 thiserror =  "1"
 itertools = "0.10.5"
 tracing = "0.1.37"
-tracing-subscriber = "0.3.17"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 lazy_static = "1.4.0"
 notify = { version = "5.1.0", default-features = false, features = ["macos_kqueue"] }
 


### PR DESCRIPTION
Slightly tidier. `RUST_LOG` works to configure logging as before, with some minor behavior changes. If `RUST_LOG` is not set then the server will still log errors.  If `RUST_LOG` is set to an unexpected value then it defaults to `error` instead of `info`. [More complex values of `RUST_LOG`](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#example-syntax) can be used.

Also adjust `main` to log and exit on error in policies/entities/schema instead of panic-and-exit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
