### PR TITLE
Update TinyTodo to include an ABAC-style policy

### DIFF
--- a/tinytodo/entities.json
+++ b/tinytodo/entities.json
@@ -2,6 +2,8 @@
   "users": {
     "User::\"kesha\"": {
       "euid": "User::\"kesha\"",
+      "location": "WAS17",
+      "joblevel": 5,
       "parents": [
         "Application::\"TinyTodo\"",
         "Team::\"temp\""
@@ -9,6 +11,8 @@
     },
     "User::\"aaron\"": {
       "euid": "User::\"aaron\"",
+      "location": "WAS17",
+      "joblevel": 5,
       "parents": [
         "Team::\"interns\"",
         "Application::\"TinyTodo\""
@@ -16,6 +20,8 @@
     },
     "User::\"emina\"": {
       "euid": "User::\"emina\"",
+      "location": "SEA33",
+      "joblevel": 8,
       "parents": [
         "Application::\"TinyTodo\"",
         "Team::\"admin\""
@@ -23,6 +29,8 @@
     },
     "User::\"andrew\"": {
       "euid": "User::\"andrew\"",
+      "location": "SJC38",
+      "joblevel": 5,
       "parents": [
         "Application::\"TinyTodo\"",
         "Team::\"admin\"",

--- a/tinytodo/entities.json
+++ b/tinytodo/entities.json
@@ -2,7 +2,7 @@
   "users": {
     "User::\"kesha\"": {
       "euid": "User::\"kesha\"",
-      "location": "WAS17",
+      "location": "ABC17",
       "joblevel": 5,
       "parents": [
         "Application::\"TinyTodo\"",
@@ -11,7 +11,7 @@
     },
     "User::\"aaron\"": {
       "euid": "User::\"aaron\"",
-      "location": "WAS17",
+      "location": "ABC17",
       "joblevel": 5,
       "parents": [
         "Team::\"interns\"",
@@ -20,7 +20,7 @@
     },
     "User::\"emina\"": {
       "euid": "User::\"emina\"",
-      "location": "SEA33",
+      "location": "DEF33",
       "joblevel": 8,
       "parents": [
         "Application::\"TinyTodo\"",
@@ -29,7 +29,7 @@
     },
     "User::\"andrew\"": {
       "euid": "User::\"andrew\"",
-      "location": "SJC38",
+      "location": "XYZ77",
       "joblevel": 5,
       "parents": [
         "Application::\"TinyTodo\"",

--- a/tinytodo/policies.cedar
+++ b/tinytodo/policies.cedar
@@ -43,3 +43,14 @@ when { principal in resource.editors };
 //     action == Action::"CreateList",
 //     resource == Application::"TinyTodo"
 // );
+//
+// Policy 6: No access if not high rank and at location DEF, 
+// or at resource's owner's location
+// forbid(
+//     principal,
+//     action,
+//     resource is List
+// ) unless {
+//     principal.joblevel > 6 && principal.location like "DEF*" ||
+//     principal.location == resource.owner.location
+// };

--- a/tinytodo/src/objects.rs
+++ b/tinytodo/src/objects.rs
@@ -95,7 +95,8 @@ impl From<User> for Entity {
             euid.into(),
             attrs,
             value.parents.into_iter().map(|euid| euid.into()).collect(),
-        ).unwrap()
+        )
+        .unwrap()
     }
 }
 

--- a/tinytodo/src/objects.rs
+++ b/tinytodo/src/objects.rs
@@ -59,6 +59,8 @@ pub trait UserOrTeam {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct User {
     euid: UserUid,
+    joblevel: i64,
+    location: String,
     parents: HashSet<EntityUid>,
 }
 
@@ -67,10 +69,12 @@ impl User {
         &self.euid
     }
 
-    pub fn new(euid: UserUid) -> Self {
+    pub fn new(euid: UserUid, joblevel: i64, location: String) -> Self {
         let parent = Application::default().euid().clone();
         Self {
             euid,
+            joblevel,
+            location,
             parents: [parent].into_iter().collect(),
         }
     }
@@ -78,11 +82,20 @@ impl User {
 
 impl From<User> for Entity {
     fn from(value: User) -> Entity {
+        let attrs = [
+            ("joblevel", RestrictedExpression::new_long(value.joblevel)),
+            ("location", RestrictedExpression::new_string(value.location)),
+        ]
+        .into_iter()
+        .map(|(x, v)| (x.into(), v))
+        .collect();
+
         let euid: EntityUid = value.euid.into();
-        Entity::new_no_attrs(
+        Entity::new(
             euid.into(),
+            attrs,
             value.parents.into_iter().map(|euid| euid.into()).collect(),
-        )
+        ).unwrap()
     }
 }
 

--- a/tinytodo/tinytodo.cedarschema.json
+++ b/tinytodo/tinytodo.cedarschema.json
@@ -6,7 +6,18 @@
 				"memberOfTypes": [
 					"Team",
 					"Application"
-				]
+				],
+				"shape": {
+					"type": "Record",
+					"attributes": {
+						"location": {
+							"type": "String"
+						},
+						"joblevel": {
+							"type": "Long"
+						}
+					}
+				}
 			},
 			"Team": {
 				"memberOfTypes": [


### PR DESCRIPTION
*Description of changes:* This is an extension of TinyTodo to include one additional policy that focuses on ABAC-style authorization. Updated the tutorial text, policies, schema, code, etc.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
