### PR TITLE
cherry-pick #113 to release/3.1.x

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -32,7 +32,9 @@ body:
       options:
         - cedar-example-use-cases
         - cedar-java-hello-world
-        - cear-rust-hello-world
+        - cedar-policy-language-in-action
+        - cedar-rust-hello-world
+        - oopsla2024-benchmarks
         - tinytodo
     validations:
       required: true
@@ -109,4 +111,3 @@ body:
         If you have any additional information, workarounds, etc. for us, use the field below.
         Please note, you can attach screenshots or screen recordings here by
         dragging and dropping files in the field below.
-

--- a/.github/ISSUE_TEMPLATE/expand_example.yml
+++ b/.github/ISSUE_TEMPLATE/expand_example.yml
@@ -16,7 +16,9 @@ body:
       options:
         - cedar-example-use-cases
         - cedar-java-hello-world
+        - cedar-policy-language-in-action
         - cedar-rust-hello-world
+        - oopsla-2024-benchmarks
         - tinytodo
     validations:
       required: true
@@ -41,4 +43,3 @@ body:
       options:
         - label: 👋 I may be able to implement this feature request
         - label: ⚠️ This feature might incur a breaking change
-


### PR DESCRIPTION
*Issue #, if available:*

#113

*Description of changes:*

It seems that since our default branch is release/3.1.x, the version of the issue templates on release/3.1.x is the one that controls.

