### PR TITLE
add format check for example use cases

### DIFF
--- a/cedar-example-use-cases/document_cloud/policies.cedar
+++ b/cedar-example-use-cases/document_cloud/policies.cedar
@@ -105,11 +105,7 @@ when
    principal.blocked.contains(resource.owner))
 };
 
-forbid (
-  principal,
-  action,
-  resource
-)
+forbid (principal, action, resource)
 when { !context.is_authenticated };
 
 forbid (principal, action, resource)

--- a/cedar-example-use-cases/github_example/policies.cedar
+++ b/cedar-example-use-cases/github_example/policies.cedar
@@ -69,8 +69,6 @@ permit (
      Action::"add_admin"],
   resource
 )
-when
-{ principal in resource.admins };
-
+when { principal in resource.admins };
 //We use the same permissions for org owners, and rely on placing them in the admins group for every repository in the org
 //The other option is to duplicate all policies for the org base permissions (with a separate heirarchy for each org)

--- a/cedar-example-use-cases/run.sh
+++ b/cedar-example-use-cases/run.sh
@@ -6,10 +6,12 @@ source ../test_utils.sh
 echo -e "\nTesting github_example..."
 validate "github_example" "policies.cedar" "github_example.cedarschema"
 authorize "github_example" "policies.cedar" "entities.json"
+format "github_example" "policies.cedar"
 
 # GitApp
 echo -e "\nTesting document_cloud..."
 validate "document_cloud" "policies.cedar" "document_cloud.cedarschema"
 authorize "document_cloud" "policies.cedar" "entities.json"
+format "document_cloud" "policies.cedar"
 
 exit "$any_failed"

--- a/cedar-policy-language-in-action/run.sh
+++ b/cedar-policy-language-in-action/run.sh
@@ -6,10 +6,12 @@ source ../test_utils.sh
 echo -e "\nTesting PhotoApp..."
 validate "PhotoApp" "photoapp.cedar" "photoapp.cedarschema"
 authorize "PhotoApp" "photoapp.cedar" "photoapp.cedarentities.json"
+format "PhotoApp" "photoapp.cedar"
 
 # GitApp
 echo -e "\nTesting GitApp..."
 validate "GitApp" "gitapp.cedar" "gitapp.cedarschema"
 authorize "GitApp" "gitapp.cedar" "gitapp.cedarentities.json"
+format "GitApp" "gitapp.cedar"
 
 exit "$any_failed"

--- a/test_utils.sh
+++ b/test_utils.sh
@@ -64,4 +64,19 @@ authorize() {
     done
 }
 
+# Call this function to assert that policies in the directory `$1/$2` are formatted. 
+# Set `any_failed` env var to `1` if a policy is not formatted.
+format() {
+    local folder=$1
+    local policies=$2
+    echo " Checking formatting of ${policies}"
+    res="$(cedar format --policies "$folder/$policies" --check)"
+    if [[ $? == 0 ]]
+    then
+        passed "format check succeeded"
+    else
+        failed "format check on ${policies} with result: ${res}"
+    fi
+}
+
 echo "Using $(cedar --version)"


### PR DESCRIPTION
*Description of changes:*

Added a format check for the policies in `cedar-example-use-cases/` and `cedar-policy-language-in-action/`. This extends the set of test cases for Cedar's formatter, helping us to know when we've made a (potentially unintended) change upstream.
