### PR TITLE
Change rust demo to use natural cedar schema instead of JSON format

### DIFF
--- a/cedar-rust-hello-world/Cargo.toml
+++ b/cedar-rust-hello-world/Cargo.toml
@@ -9,4 +9,8 @@ publish = false
 serde_json = "1.0"
 
 [dependencies.cedar-policy]
-path = "../../cedar/cedar-policy"
+version = "4.0.0"
+git = "https://github.com/cedar-policy/cedar"
+branch = "main"
+#Do not add any lines below this. CI relies on the previous line being the second-to-last line in the file
+

--- a/cedar-rust-hello-world/Cargo.toml
+++ b/cedar-rust-hello-world/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 serde_json = "1.0"
 
 [dependencies.cedar-policy]
-version = "3.0.0"
+path = "../../cedar/cedar-policy"

--- a/cedar-rust-hello-world/src/main.rs
+++ b/cedar-rust-hello-world/src/main.rs
@@ -357,25 +357,7 @@ fn print_response(ans: Response) {
 /// This uses the waterford API to call the authorization engine.
 fn execute_query(request: &Request, policies: &PolicySet, entities: Entities) -> Response {
     let authorizer = Authorizer::new();
-    authorizer.is_authorized(request, &policies, &entities)
-}
-
-fn schema() -> Schema {
-    let schema = r#"
-entity UserGroup;
-entity User in [UserGroup] = {
-  "age": Long
-};
-entity Album;
-action view appliesTo {
-  principal: [User],
-  resource: [Album]
-};
-    "#;
-    // the schema can be parsed in rust:
-    let (natural_schema, warnings) = Schema::from_str_natural(schema).unwrap();
-    assert_eq!(warnings.count(), 0);
-    natural_schema
+    authorizer.is_authorized(request, policies, &entities)
 }
 
 fn validate() {
@@ -393,7 +375,21 @@ fn validate() {
     };
 "#;
     let p = PolicySet::from_str(src).unwrap();
-    let schema = schema();
+
+    let schema_text = r#"
+entity UserGroup;
+entity User in [UserGroup] = {
+  "age": Long
+};
+entity Album;
+action view appliesTo {
+  principal: [User],
+  resource: [Album]
+};
+    "#;
+    // the schema can be parsed in rust:
+    let (schema, warnings) = Schema::from_str_natural(schema_text).unwrap();
+    assert_eq!(warnings.count(), 0);
     let validator = Validator::new(schema);
 
     let result = Validator::validate(&validator, &p, ValidationMode::default());


### PR DESCRIPTION
Currently, the rust api tutorial is a bit weird because it uses the JSON format for schemas. This PR converts the example to use the natural cedar language instead.

Related, this PR exposes json serialization so we could demo going back and forth from JSON in the future: https://github.com/cedar-policy/cedar/pull/949