### PR TITLE
Updating TUTORIAL to reflect current Cedar schema format

### DIFF
--- a/tinytodo/README.md
+++ b/tinytodo/README.md
@@ -37,7 +37,7 @@ To start the server, from the Python primary prompt `>>>` enter
 start_server()
 ```
 
-When it starts up, the server reads in the Cedar policies in `policies.cedar`, and the Cedar entities, which define the TinyTodo `User`s and `Team`s, from `entities.json`. It validates the policies are consistent with `tinytodo.cedarschema.json`, and will abort if they are not.
+When it starts up, the server reads in the Cedar policies in `policies.cedar`, and the Cedar entities, which define the TinyTodo `User`s and `Team`s, from `entities.json`. It validates the policies are consistent with `tinytodo.cedarschema`, and will abort if they are not.
 
 Client code `tinytodo.py` defines the functions you can call, which serve as the list of commands. See also [`TUTORIAL.md`](./TUTORIAL.md) for a detailed description of how to use these commands, and how TinyTodo works. Here is a brief description of the commands:
 

--- a/tinytodo/TUTORIAL.md
+++ b/tinytodo/TUTORIAL.md
@@ -330,7 +330,7 @@ In words, the policies can be described as follows:
 
 0. Any user can perform actions `CreateList`, `GetLists` (to create a list, and enumerate owned lists, respectively).
 1. The `List` owner can perform any action on it (`EditList`, `DeleteList`, `CreateTask`, ...).
-2. A `List` reader and editor can perform read actions on it (`GetList`).
+2. A `List` reader or editor can perform read actions on it (`GetList`).
 3. A `List` editor can perform write actions on it (`UpdateList`, `CreateTask`, `DeleteTask`, ...).
 
 To see how these policies affect the outcome, suppose user `kesha` attempts to create a task `"write release notes"` for list ID 0, which `andrew` created. This will result in the `create_task` handler being called, which we looked at earlier, which in turn will call `is_authorized` with a Cedar `Request` asking whether principal `User::"kesha"`  can perform action `Action::"CreateTask"` on resource `List::"0"`. The `is_authorized` call will also include the entities `&es` constructed from our `EntityStore`, which the Cedar authorization engine can consult when it evaluates each of the provided policies, one at a time. 


### PR DESCRIPTION
*Issue #, if available:* N/A
*Description of changes:*
- Updated TUTORIAL.md to describe the new Cedar entity schema
- Updated human description of policy example to match more accurately the cedar policies
- When describing the policy LIKE "DEF*", instead of saying that is "DEF", say that it starts with "DEF"

