### PR TITLE
build wasm example in CI

### DIFF
--- a/.github/workflows/build_rust_hello_world_reusable.yml
+++ b/.github/workflows/build_rust_hello_world_reusable.yml
@@ -3,11 +3,10 @@ on:
     workflow_call:
       inputs:
         cedar_policy_ref:
-          required: false
+          required: true
           type: string
         cedar_examples_ref:
-          required: false
-          default: "main"
+          required: true
           type: string
 
 jobs:
@@ -20,7 +19,7 @@ jobs:
           - stable
     steps:
       - name: Checkout Cedar Examples
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: cedar-policy/cedar-examples
           ref: ${{ inputs.cedar_examples_ref }}

--- a/.github/workflows/build_rust_hello_world_reusable.yml
+++ b/.github/workflows/build_rust_hello_world_reusable.yml
@@ -1,4 +1,4 @@
-name: Build and Test RustHelloWorld
+name: Build and test Rust example
 on:
     workflow_call:
       inputs:
@@ -11,14 +11,14 @@ on:
 
 jobs:
   build_and_test_rust_hello_world:
-    name: rust-hello-world
+    name: Build and test Rust example
     runs-on: ubuntu-latest
     strategy:
       matrix:
         toolchain:
           - stable
     steps:
-      - name: Checkout Cedar Examples
+      - name: Checkout cedar-examples
         uses: actions/checkout@v4
         with:
           repository: cedar-policy/cedar-examples

--- a/.github/workflows/build_rust_hello_world_reusable.yml
+++ b/.github/workflows/build_rust_hello_world_reusable.yml
@@ -23,9 +23,7 @@ jobs:
         with:
           repository: cedar-policy/cedar-examples
           ref: ${{ inputs.cedar_examples_ref }}
-# If we passed a branch for cedar-policy, modify Cargo.toml to use that branch
-      - name: Replace Crates dot IO with Github version
-        if: "${{ inputs.cedar_policy_ref != '' }}"
+      - name: Replace crates.io version with Github version
         run: cd cedar-rust-hello-world && printf "\n[patch.crates-io]\ncedar-policy = { git = 'https://github.com/cedar-policy/cedar.git', rev = '${{ inputs.cedar_policy_ref }}'}" >> Cargo.toml
       - name: rustup
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}

--- a/.github/workflows/build_tiny_todo_reusable.yml
+++ b/.github/workflows/build_tiny_todo_reusable.yml
@@ -3,11 +3,10 @@ on:
     workflow_call:
       inputs:
         cedar_policy_ref:
-          required: false
+          required: true
           type: string
         cedar_examples_ref:
-          required: false
-          default: "main"
+          required: true
           type: string
 
 jobs:
@@ -20,7 +19,7 @@ jobs:
           - stable
     steps:
       - name: Checkout Cedar Examples
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: cedar-policy/cedar-examples
           ref: ${{ inputs.cedar_examples_ref }}

--- a/.github/workflows/build_tiny_todo_reusable.yml
+++ b/.github/workflows/build_tiny_todo_reusable.yml
@@ -1,4 +1,4 @@
-name: Build and Test TinyTodo
+name: Build and test TinyTodo
 on:
     workflow_call:
       inputs:
@@ -11,14 +11,14 @@ on:
 
 jobs:
   build_and_test_tiny_todo:
-    name: Build and Test TinyTodo
+    name: Build and test TinyTodo
     runs-on: ubuntu-latest
     strategy:
       matrix:
         toolchain:
           - stable
     steps:
-      - name: Checkout Cedar Examples
+      - name: Checkout cedar-examples
         uses: actions/checkout@v4
         with:
           repository: cedar-policy/cedar-examples

--- a/.github/workflows/build_tiny_todo_reusable.yml
+++ b/.github/workflows/build_tiny_todo_reusable.yml
@@ -23,9 +23,7 @@ jobs:
         with:
           repository: cedar-policy/cedar-examples
           ref: ${{ inputs.cedar_examples_ref }}
-# If we passed a branch for cedar-policy, modify Cargo.toml to use that branch
-      - name: Replace main with Specified Branch
-        if: "${{ inputs.cedar_policy_ref != '' }}"
+      - name: Use the specified branch
         run: cd tinytodo && head -n -2 Cargo.toml > Temp.toml && mv Temp.toml Cargo.toml && printf 'rev = "${{ inputs.cedar_policy_ref }}"' >> Cargo.toml
       - name: rustup
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}

--- a/.github/workflows/build_wasm_example_reusable.yml
+++ b/.github/workflows/build_wasm_example_reusable.yml
@@ -31,8 +31,8 @@ jobs:
           path: ./cedar
       - name: rustup
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
+      - name: Install wasm-pack
+        run: cargo install wasm-pack
       - name: Build Cedar Wasm
         working-directory: ./cedar/cedar-wasm
         run: ./build-wasm.sh

--- a/.github/workflows/build_wasm_example_reusable.yml
+++ b/.github/workflows/build_wasm_example_reusable.yml
@@ -1,0 +1,47 @@
+name: Build and Test Wasm Example
+on:
+    workflow_call:
+      inputs:
+        cedar_policy_ref:
+          required: true
+          type: string
+        cedar_examples_ref:
+          required: true
+          type: string
+
+jobs:
+  build_and_test_wasm_example:
+    name: wasm-example
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+    steps:
+      - name: Checkout cedar-examples
+        uses: actions/checkout@v4
+        with:
+          repository: cedar-policy/cedar-examples
+          ref: ${{ inputs.cedar_examples_ref }}
+      - name: Checkout cedar
+        uses: actions/checkout@v4
+        with:
+          repository: cedar-policy/cedar
+          ref: ${{ inputs.cedar_policy_ref }}
+          path: ./cedar
+      - name: rustup
+        run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
+      - name: Build Cedar Wasm
+        working-directory: ./cedar/cedar-wasm
+        run: ./build-wasm.sh
+      - name: Replace npm version with Github version
+        working-directory: ./cedar-wasm-example
+        run: sed -i "s/\"@cedar-policy\/cedar-wasm\": .*/\"@cedar-policy\/cedar-wasm\": \"file:..\/cedar\/cedar-wasm\/pkg\"/" package.json
+      - name: npm i
+        working-directory: ./cedar-wasm-example
+        run: npm i
+      - name: npm t
+        working-directory: ./cedar-wasm-example
+        run: npm t

--- a/.github/workflows/build_wasm_example_reusable.yml
+++ b/.github/workflows/build_wasm_example_reusable.yml
@@ -38,7 +38,8 @@ jobs:
         run: ./build-wasm.sh
       - name: Replace npm version with Github version
         working-directory: ./cedar-wasm-example
-        run: sed -i "s/\"@cedar-policy\/cedar-wasm\": .*/\"@cedar-policy\/cedar-wasm\": \"file:..\/cedar\/cedar-wasm\/pkg\"/" package.json
+        run: |
+          sed -i "s/\"@cedar-policy\/cedar-wasm\": .*/\"@cedar-policy\/cedar-wasm\": \"file:..\/cedar\/cedar-wasm\/pkg\"/" package.json
       - name: npm i
         working-directory: ./cedar-wasm-example
         run: npm i

--- a/.github/workflows/build_wasm_example_reusable.yml
+++ b/.github/workflows/build_wasm_example_reusable.yml
@@ -1,4 +1,4 @@
-name: Build and Test Wasm Example
+name: Build and test Wasm example
 on:
     workflow_call:
       inputs:
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build_and_test_wasm_example:
-    name: wasm-example
+    name: Build and test Wasm example
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -33,7 +33,7 @@ jobs:
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - name: Install wasm-pack
         run: cargo install wasm-pack
-      - name: Build Cedar Wasm
+      - name: Build cedar-wasm
         working-directory: ./cedar/cedar-wasm
         run: ./build-wasm.sh
       - name: Replace npm version with Github version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,9 @@ jobs:
           distribution: 'corretto'
           java-version: '17'
       - name: Checkout cedar-examples
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Checkout cedar-java
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: cedar-policy/cedar-java
           ref: release/2.3.x # Java example currently only builds for 2.3.3
@@ -56,31 +56,39 @@ jobs:
     needs: get-branch-name
     uses: ./.github/workflows/run_example_use_cases_reusable.yml
     with:
-      cedar_policy_ref: "refs/heads/main" # use the latest commit on main
-      cedar_examples_ref: "${{ github.href }}" # use the current PR's commit
+      cedar_policy_ref: refs/heads/${{ needs.get-branch-name.outputs.branch_name }}
+      cedar_examples_ref: ${{ github.href }}
 
   build_rust_hello_world:
     name: rust_hello_world
     needs: get-branch-name
     uses: ./.github/workflows/build_rust_hello_world_reusable.yml
     with:
-      cedar_policy_ref: "refs/heads/main" # use the latest commit on main
-      cedar_examples_ref: "${{ github.href }}" # use the current PR's commit
+      cedar_policy_ref: refs/heads/${{ needs.get-branch-name.outputs.branch_name }}
+      cedar_examples_ref: ${{ github.href }}
+
+  build_wasm_example:
+    name: wasm_example
+    needs: get-branch-name
+    uses: ./.github/workflows/build_wasm_example_reusable.yml
+    with:
+      cedar_policy_ref: refs/heads/${{ needs.get-branch-name.outputs.branch_name }}
+      cedar_examples_ref: ${{ github.href }}
 
   build_tiny_todo:
     name: tinytodo
     needs: get-branch-name
     uses: ./.github/workflows/build_tiny_todo_reusable.yml
     with:
-      cedar_policy_ref: "refs/heads/main" # use the latest commit on main
-      cedar_examples_ref: "${{ github.href }}" # use the current PR's commit
+      cedar_policy_ref: refs/heads/${{ needs.get-branch-name.outputs.branch_name }}
+      cedar_examples_ref: ${{ github.href }}
 
   build_and_run_oopsla_benchmarks:
     name: OOPSLA2024 benchmarks
     runs-on: ubuntu-latest
     steps:
       - name: Checkout cedar-examples
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build Docker image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Cargo Build & Test
+name: Build & Test Examples
 
 on:
   pull_request:
@@ -19,15 +19,15 @@ jobs:
     outputs:
       branch_name: ${{ steps.get_branch_name.outputs.branch_name }}
 
-  build_and_test_java_hello_world:
-    name: java-hello-world
+  java-hello-world:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         toolchain:
           - stable
     steps:
-      - uses: actions/setup-java@v3
+      - name: Setup Java
+        uses: actions/setup-java@v4
         with:
           distribution: 'corretto'
           java-version: '17'
@@ -41,7 +41,7 @@ jobs:
           path: ./cedar-java-hello-world/cedar-java
       - name: rustup
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
-      - name: cargo build CedarJavaFFI
+      - name: Build CedarJavaFFI
         working-directory: ./cedar-java-hello-world/cedar-java/CedarJavaFFI
         run: cargo build
       - name: Build cedar-java-hello-world
@@ -51,32 +51,28 @@ jobs:
         working-directory: ./cedar-java-hello-world
         run: ./gradlew test
 
-  run_example_use_cases:
-    name: run_example_use_cases
+  run-example-use-cases:
     needs: get-branch-name
     uses: ./.github/workflows/run_example_use_cases_reusable.yml
     with:
       cedar_policy_ref: refs/heads/${{ needs.get-branch-name.outputs.branch_name }}
       cedar_examples_ref: ${{ github.href }}
 
-  build_rust_hello_world:
-    name: rust_hello_world
+  rust-hello-world:
     needs: get-branch-name
     uses: ./.github/workflows/build_rust_hello_world_reusable.yml
     with:
       cedar_policy_ref: refs/heads/${{ needs.get-branch-name.outputs.branch_name }}
       cedar_examples_ref: ${{ github.href }}
 
-  build_wasm_example:
-    name: wasm_example
+  wasm-example:
     needs: get-branch-name
     uses: ./.github/workflows/build_wasm_example_reusable.yml
     with:
       cedar_policy_ref: refs/heads/${{ needs.get-branch-name.outputs.branch_name }}
       cedar_examples_ref: ${{ github.href }}
 
-  build_tiny_todo:
-    name: tinytodo
+  tinytodo:
     needs: get-branch-name
     uses: ./.github/workflows/build_tiny_todo_reusable.yml
     with:
@@ -92,7 +88,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           push: false
           context: oopsla2024-benchmarks

--- a/.github/workflows/run_example_use_cases_reusable.yml
+++ b/.github/workflows/run_example_use_cases_reusable.yml
@@ -20,12 +20,12 @@ jobs:
           - stable
     steps:
       - name: Checkout Cedar Examples
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: cedar-policy/cedar-examples
           ref: ${{ inputs.cedar_examples_ref }}
       - name: Checkout cedar-policy
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: cedar-policy/cedar
           ref: ${{ inputs.cedar_policy_ref }}

--- a/.github/workflows/run_example_use_cases_reusable.yml
+++ b/.github/workflows/run_example_use_cases_reusable.yml
@@ -1,25 +1,24 @@
-name: Run Example Use Cases
+name: Run example use cases
 on:
     workflow_call:
       inputs:
         cedar_policy_ref:
-          required: false
+          required: true
           type: string
         cedar_examples_ref:
-          required: false
-          default: "main"
+          required: true
           type: string
 
 jobs:
   run_example_use_cases:
-    name: example-use-cases
+    name: Run example use cases
     runs-on: ubuntu-latest
     strategy:
       matrix:
         toolchain:
           - stable
     steps:
-      - name: Checkout Cedar Examples
+      - name: Checkout cedar-examples
         uses: actions/checkout@v4
         with:
           repository: cedar-policy/cedar-examples
@@ -32,16 +31,16 @@ jobs:
           path: ./cedar
       - name: rustup
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
-      - name: build cli
+      - name: Build cli
         working-directory: ./cedar
         run: cargo build --bin cedar
-      - name: run validation and authorization
+      - name: Run validation and authorization
         working-directory: ./cedar-example-use-cases
         run: |
              export PATH="$PWD/../cedar/target/debug/":$PATH
              echo $PATH
              ./run.sh
-      - name: run validation and authorization for cedar-policy-language-in-action
+      - name: Run validation and authorization for cedar-policy-language-in-action
         working-directory: ./cedar-policy-language-in-action
         run: |
              export PATH="$PWD/../cedar/target/debug/":$PATH

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more inform
 
 This project is licensed under the Apache-2.0 License.
 
-[Cedar Rust APIs]: https://github.com/cedar-policy/cedar/tree/main/cedar-policy
+[Cedar Rust APIs]: https://docs.rs/cedar-policy/latest/cedar_policy
 [Cedar Java APIs]: https://github.com/cedar-policy/cedar-java
 [Cedar Wasm APIs]: https://github.com/cedar-policy/cedar/tree/main/cedar-wasm
 [`cedar-example-use-cases`]: ./cedar-example-use-cases

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository contains examples demonstrating the use of [Cedar](https://githu
 | [`tinytodo`][] | Rust, Python | A simple application for managing task lists that uses Cedar for authorization |
 | [`cedar-java-hello-world`][] | Java | A simple application demonstrating the usage of the [Cedar Java APIs][] |
 | [`cedar-rust-hello-world`][] | Rust | A simple application demonstrating the usage of the [Cedar Rust APIs][] |
+| [`cedar-wasm-example`][] | TypeScript | A simple application demonstrating the usage of the [Cedar Wasm APIs][] |
 | [`cedar-policy-language-in-action`][] | Cedar | Cedar policies and schemas for the [Cedar policy language in action](https://catalog.workshops.aws/cedar-policy-language-in-action) workshop |
 | [`cedar-example-use-cases`][] |  Cedar  | Cedar policies and schemas for two example applications |
 | [`oopsla2024-benchmarks`][] | Various | Cedar policies and schemas, along with benchmarking code and scripts, used for the performance evaluation of the [OOPSLA2024 paper on Cedar](https://dl.acm.org/doi/10.1145/3649835) |
@@ -21,9 +22,11 @@ This project is licensed under the Apache-2.0 License.
 
 [Cedar Rust APIs]: https://github.com/cedar-policy/cedar/tree/main/cedar-policy
 [Cedar Java APIs]: https://github.com/cedar-policy/cedar-java
+[Cedar Wasm APIs]: https://github.com/cedar-policy/cedar/tree/main/cedar-wasm
 [`cedar-example-use-cases`]: ./cedar-example-use-cases
 [`cedar-java-hello-world`]: ./cedar-java-hello-world
 [`cedar-rust-hello-world`]: ./cedar-rust-hello-world
+[`cedar-wasm-example`]: ./cedar-wasm-example
 [`cedar-policy-language-in-action`]: ./cedar-policy-language-in-action
 [`oopsla2024-benchmarks`]: ./oopsla2024-benchmarks
 [`tinytodo`]: ./tinytodo

--- a/cedar-java-hello-world/README.md
+++ b/cedar-java-hello-world/README.md
@@ -26,11 +26,3 @@ cd ../.. && bash config.sh && ./gradlew build
 ```shell
 ./gradlew test
 ```
-
-## Security
-
-See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
-
-## License
-
-This project is licensed under the Apache-2.0 License.

--- a/cedar-wasm-example/README.md
+++ b/cedar-wasm-example/README.md
@@ -6,7 +6,7 @@ This repo runs tests against wasm code and exemplifies how to use many of the fe
 
 Simply install the packages with `npm i` and then run the tests with `npm t`:
 
-```
+```bash
 cd cedar-wasm-example
 npm i
 npm t
@@ -14,13 +14,13 @@ npm t
 
 ## Testing an unreleased cedar version
 
-First, have the cedar-policy package checked out.
+First, have the [cedar](https://github.com/cedar-policy/cedar) repository checked out.
 
-Make your changes, then build cedar wasm by using the `build.sh` script in that package.
+Make your changes, then build cedar wasm by using the `cedar-wasm/build-wasm.sh` script in that repository.
 
 Then, change this package's `package.json` to point to your local built wasm package. The entry in `package.json` should look something like:
 
-```
+```json
 "dependencies": {
     "@cedar-policy/cedar-wasm": "file:../../cedar/cedar-wasm/pkg/"
   },

--- a/cedar-wasm-example/README.md
+++ b/cedar-wasm-example/README.md
@@ -6,7 +6,7 @@ This repo runs tests against wasm code and exemplifies how to use many of the fe
 
 Simply install the packages with `npm i` and then run the tests with `npm t`:
 
-```bash
+```shell
 cd cedar-wasm-example
 npm i
 npm t

--- a/cedar-wasm-example/__tests__/main.test.ts
+++ b/cedar-wasm-example/__tests__/main.test.ts
@@ -17,7 +17,7 @@ describe('Authorizer tests', () => {
         if (authResult.type !== 'success') {
             throw new Error(`Expected success in evaluation, got ${JSON.stringify(authResult, null, 4)}`);
         }
-        expect(authResult.response.decision).toBe('Deny');
+        expect(authResult.response.decision).toBe('deny');
     });
     
     test('isAuthorized test without schema, should allow', () => {
@@ -36,7 +36,7 @@ describe('Authorizer tests', () => {
         if (authResult.type !== 'success') {
             throw new Error(`Expected success in evaluation, got ${JSON.stringify(authResult, null, 4)}`);
         }
-        expect(authResult.response.decision).toBe('Allow');
+        expect(authResult.response.decision).toBe('allow');
     });
 
     test('isAuthorized test with schema, should allow', () => {
@@ -94,7 +94,7 @@ describe('Authorizer tests', () => {
         if (authResult.type !== 'success') {
             throw new Error(`Expected success in evaluation, got ${JSON.stringify(authResult, null, 4)}`);
         }
-        expect(authResult.response.decision).toBe('Allow');
+        expect(authResult.response.decision).toBe('allow');
     });
 
     test('isAuthorized test with invalid schema, should error', () => {
@@ -316,7 +316,7 @@ describe('policy and template parsing', () => {
     });
 });
 
-const SCHEMA: cedar.SchemaJson = {
+const SCHEMA = {
     App: {
         commonTypes: {
             ActionContext: {
@@ -390,11 +390,11 @@ describe('validator tests', () => {
             };
         `;
         const validationResult = cedar.validate({
-            validationSettings: { enabled: 'on' },
+            validationSettings: { mode: "strict", enabled: true },
             schema: {
                 json: SCHEMA,
             },
-            policySet: policyText
+            policies: policyText
         });
         if (validationResult.type !== 'success') {
             throw new Error(`Expected success in validation, got ${JSON.stringify(validationResult, null, 4)}`);
@@ -414,11 +414,11 @@ describe('validator tests', () => {
             };
         `;
         const validationResult = cedar.validate({
-            validationSettings: { enabled: 'on' },
+            validationSettings: { mode: "strict", enabled: true },
             schema: {
                 json: SCHEMA,
             },
-            policySet: policyText
+            policies: policyText
         });
         if (validationResult.type !== 'success') {
             throw new Error(`Expected success in validation, got ${JSON.stringify(validationResult, null, 4)}`);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Add CI to build & test Wasm example
* Minor cleanup in the Wasm example READMEs
* Fixes in the Wasm tests to match the current state of `cedar`'s `main` branch
* Various CI nits for consistency

I plan to backport these changes to the latest release (3.2.x).
