### PR TITLE
Fixing `cedar-java-hello-world` for cedar-examples `release/3.2.x`

### DIFF
--- a/.github/workflows/build_java_hello_world_reusable.yml
+++ b/.github/workflows/build_java_hello_world_reusable.yml
@@ -23,6 +23,10 @@ jobs:
         with:
           distribution: 'corretto'
           java-version: '17'
+      - name: Setup Zig
+        uses: goto-bus-stop/setup-zig@v2.2.0
+        with:
+          version: 0.11.0
       - name: Checkout cedar-examples
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build_java_hello_world_reusable.yml
+++ b/.github/workflows/build_java_hello_world_reusable.yml
@@ -54,7 +54,7 @@ jobs:
           sed -i "s/'com.cedarpolicy:cedar-java:.*/files('cedar-java\/CedarJava\/build\/libs\/CedarJava.jar')/" build.gradle
       - name: Build cedar-java-hello-world
         working-directory: ./cedar-java-hello-world
-        run: bash config.sh && ./gradlew build
+        run: bash config.sh && ./gradlew build --info
       - name: Run cedar-java-hello-world
         working-directory: ./cedar-java-hello-world
         run: ./gradlew test

--- a/.github/workflows/build_java_hello_world_reusable.yml
+++ b/.github/workflows/build_java_hello_world_reusable.yml
@@ -39,6 +39,13 @@ jobs:
       - name: Build CedarJavaFFI
         working-directory: ./cedar-java-hello-world/cedar-java/CedarJavaFFI
         run: cargo build
+      - name: Build CedarJava
+        working-directory: ./cedar-java-hello-world/cedar-java/CedarJava
+        run: ./gradlew build
+      - name: Replace Maven version with Github version
+        working-directory: ./cedar-java-hello-world
+        run: |
+          sed -i "s/'com.cedarpolicy:cedar-java:.*/files('cedar-java\/CedarJava\/build\/libs\/CedarJava.jar')/" build.gradle
       - name: Build cedar-java-hello-world
         working-directory: ./cedar-java-hello-world
         run: bash config.sh && ./gradlew build

--- a/.github/workflows/build_java_hello_world_reusable.yml
+++ b/.github/workflows/build_java_hello_world_reusable.yml
@@ -2,7 +2,7 @@ name: Build and test Java example
 on:
   workflow_call:
     inputs:
-      cedar_policy_ref:
+      cedar_java_ref:
         required: true
         type: string
       cedar_examples_ref:
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: cedar-policy/cedar-java
-          ref: ${{ inputs.cedar_policy_ref }}
+          ref: ${{ inputs.cedar_java_ref }}
           path: ./cedar-java-hello-world/cedar-java
       - name: rustup
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}

--- a/.github/workflows/build_java_hello_world_reusable.yml
+++ b/.github/workflows/build_java_hello_world_reusable.yml
@@ -26,7 +26,9 @@ jobs:
           distribution: 'corretto'
           java-version: '17'
       - name: Setup Zig
-        run: wget https://ziglang.org/download/0.11.0/zig-linux-x86_64-0.11.0.tar.xz -O - | tar xJ && echo "$(pwd)/zig-linux-x86_64-0.11.0" >> $GITHUB_PATH
+        uses: goto-bus-stop/setup-zig@v2.2.0
+        with:
+          version: 0.11.0
       - name: Checkout cedar-examples
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build_java_hello_world_reusable.yml
+++ b/.github/workflows/build_java_hello_world_reusable.yml
@@ -17,18 +17,12 @@ jobs:
       matrix:
         toolchain:
           - stable
-    env:
-      RUST_BACKTRACE: full
     steps:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
           distribution: 'corretto'
           java-version: '17'
-      - name: Setup Zig
-        uses: goto-bus-stop/setup-zig@v2.2.0
-        with:
-          version: 0.11.0
       - name: Checkout cedar-examples
         uses: actions/checkout@v4
         with:
@@ -45,16 +39,9 @@ jobs:
       - name: Build CedarJavaFFI
         working-directory: ./cedar-java-hello-world/cedar-java/CedarJavaFFI
         run: cargo build
-      - name: Build CedarJava
-        working-directory: ./cedar-java-hello-world/cedar-java/CedarJava
-        run: ./gradlew build
-      - name: Replace Maven version with Github version
-        working-directory: ./cedar-java-hello-world
-        run: |
-          sed -i "s/'com.cedarpolicy:cedar-java:.*/files('cedar-java\/CedarJava\/build\/libs\/CedarJava.jar')/" build.gradle
       - name: Build cedar-java-hello-world
         working-directory: ./cedar-java-hello-world
-        run: bash config.sh && ./gradlew build --info
+        run: bash config.sh && ./gradlew build
       - name: Run cedar-java-hello-world
         working-directory: ./cedar-java-hello-world
         run: ./gradlew test

--- a/.github/workflows/build_java_hello_world_reusable.yml
+++ b/.github/workflows/build_java_hello_world_reusable.yml
@@ -26,9 +26,7 @@ jobs:
           distribution: 'corretto'
           java-version: '17'
       - name: Setup Zig
-        uses: goto-bus-stop/setup-zig@v2.2.0
-        with:
-          version: 0.11.0
+        run: wget https://ziglang.org/download/0.11.0/zig-linux-x86_64-0.11.0.tar.xz -O - | tar xJ && echo "$(pwd)/zig-linux-x86_64-0.11.0" >> $GITHUB_PATH
       - name: Checkout cedar-examples
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build_java_hello_world_reusable.yml
+++ b/.github/workflows/build_java_hello_world_reusable.yml
@@ -1,0 +1,47 @@
+name: Build and test Java example
+on:
+  workflow_call:
+    inputs:
+      cedar_policy_ref:
+        required: true
+        type: string
+      cedar_examples_ref:
+        required: true
+        type: string
+
+jobs:
+  build_and_test_java_hello_world:
+    name: Build and test Java example
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+    steps:
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: '17'
+      - name: Checkout cedar-examples
+        uses: actions/checkout@v4
+        with:
+          repository: cedar-policy/cedar-examples
+          ref: ${{ inputs.cedar_examples_ref }}
+      - name: Checkout cedar-java
+        uses: actions/checkout@v4
+        with:
+          repository: cedar-policy/cedar-java
+          ref: ${{ inputs.cedar_policy_ref }}
+          path: ./cedar-java-hello-world/cedar-java
+      - name: rustup
+        run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - name: Build CedarJavaFFI
+        working-directory: ./cedar-java-hello-world/cedar-java/CedarJavaFFI
+        run: cargo build
+      - name: Build cedar-java-hello-world
+        working-directory: ./cedar-java-hello-world
+        run: bash config.sh && ./gradlew build
+      - name: Run cedar-java-hello-world
+        working-directory: ./cedar-java-hello-world
+        run: ./gradlew test

--- a/.github/workflows/build_java_hello_world_reusable.yml
+++ b/.github/workflows/build_java_hello_world_reusable.yml
@@ -17,6 +17,8 @@ jobs:
       matrix:
         toolchain:
           - stable
+    env:
+      RUST_BACKTRACE: full
     steps:
       - name: Setup Java
         uses: actions/setup-java@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     needs: get-branch-name
     uses: ./.github/workflows/build_java_hello_world_reusable.yml
     with:
-      cedar_policy_ref: refs/heads/${{ needs.get-branch-name.outputs.branch_name }}
+      cedar_java_ref: refs/heads/${{ needs.get-branch-name.outputs.branch_name }}
       cedar_examples_ref: ${{ github.href }}
 
   run-example-use-cases:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,36 +20,11 @@ jobs:
       branch_name: ${{ steps.get_branch_name.outputs.branch_name }}
 
   java-hello-world:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        toolchain:
-          - stable
-    steps:
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'corretto'
-          java-version: '17'
-      - name: Checkout cedar-examples
-        uses: actions/checkout@v4
-      - name: Checkout cedar-java
-        uses: actions/checkout@v4
-        with:
-          repository: cedar-policy/cedar-java
-          ref: release/2.3.x # Java example currently only builds for 2.3.3
-          path: ./cedar-java-hello-world/cedar-java
-      - name: rustup
-        run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
-      - name: Build CedarJavaFFI
-        working-directory: ./cedar-java-hello-world/cedar-java/CedarJavaFFI
-        run: cargo build
-      - name: Build cedar-java-hello-world
-        working-directory: ./cedar-java-hello-world
-        run: bash config.sh && ./gradlew build
-      - name: Run cedar-java-hello-world
-        working-directory: ./cedar-java-hello-world
-        run: ./gradlew test
+    needs: get-branch-name
+    uses: ./.github/workflows/build_java_hello_world_reusable.yml
+    with:
+      cedar_policy_ref: refs/heads/${{ needs.get-branch-name.outputs.branch_name }}
+      cedar_examples_ref: ${{ github.href }}
 
   run-example-use-cases:
     needs: get-branch-name

--- a/cedar-java-hello-world/README.md
+++ b/cedar-java-hello-world/README.md
@@ -1,24 +1,38 @@
 # Cedar Java Hello World
 
 This repository contains a simple hello world program written in Java, using Cedar.
-It shows how to use of the Cedar Java API to evaluate a simple policy. You can look at the gradle files to see how to build CedarJava in your own Java applications.
+It shows how to use the Cedar Java API to evaluate a simple policy. You can look at the gradle files to see how to build CedarJava in your own Java applications.
 
 ## Usage
 
 The Java example works with the version of Cedar available on Maven, which (at the time of writing) is v3.1.2.
 
-To build, you'll need CedarJava and CedarJavaFFI. You will need to ensure that CedarJava is able to find the dynamic library of Cedar. To do that, you need to ensure the environment variable `CEDAR_JAVA_FFI_LIB` gives the location of your `cedar_java_ffi` shared library. Typically this can be done by running:
+### Build
+
+#### Building with the Maven release
+
+You can switch to the cedar-java uber jar in `build.gradle` so that the example runs using both the CedarJava and
+CedarJavaFFI libraries from the Maven release of cedar-java:3.1.2.
 
 ```shell
-bash config.sh
+# Change the build.gradle to use the uber jar
+sed -i '' "s/'com.cedarpolicy:cedar-java:3.1.2'/'com.cedarpolicy:cedar-java:3.1.2:uber'/" build.gradle
+./gradlew build
 ```
 
-### Build
+#### Building locally
+
+To build locally, pull the corresponding 3.2.x release of cedar-java and build both CedarJavaFFI and CedarJava in your workspace.
+You will need to ensure that CedarJava is able to find the dynamic library of Cedar. To do that, you need to ensure the
+environment variable `CEDAR_JAVA_FFI_LIB` gives the location of your `cedar_java_ffi` shared library. Typically this can be done by running `config.sh`:
 
 ```shell
 git clone -b release/3.2.x https://github.com/cedar-policy/cedar-java.git
 cd cedar-java/CedarJavaFFI && cargo build
-cd ../.. && bash config.sh && ./gradlew build
+cd ../CedarJava && ./gradlew build
+# Change the build.gradle to reference the jar built locally in the step above
+cd ../.. && sed -i '' "s/'com.cedarpolicy:cedar-java:.*/files('cedar-java\/CedarJava\/build\/libs\/CedarJava.jar')/" build.gradle
+bash config.sh && ./gradlew build
 ```
 
 ### Run

--- a/cedar-java-hello-world/README.md
+++ b/cedar-java-hello-world/README.md
@@ -5,7 +5,7 @@ It shows how to use of the Cedar Java API to evaluate a simple policy. You can l
 
 ## Usage
 
-The Java example works with the version of Cedar available on Maven, which (at the time of writing) is v2.3.3.
+The Java example works with the version of Cedar available on Maven, which (at the time of writing) is v3.1.2.
 
 To build, you'll need CedarJava and CedarJavaFFI. You will need to ensure that CedarJava is able to find the dynamic library of Cedar. To do that, you need to ensure the environment variable `CEDAR_JAVA_FFI_LIB` gives the location of your `cedar_java_ffi` shared library. Typically this can be done by running:
 
@@ -16,7 +16,7 @@ bash config.sh
 ### Build
 
 ```shell
-git clone -b release/2.3.x https://github.com/cedar-policy/cedar-java.git
+git clone -b release/3.2.x https://github.com/cedar-policy/cedar-java.git
 cd cedar-java/CedarJavaFFI && cargo build
 cd ../.. && bash config.sh && ./gradlew build
 ```

--- a/cedar-java-hello-world/README.md
+++ b/cedar-java-hello-world/README.md
@@ -3,24 +3,17 @@
 This repository contains a simple hello world program written in Java, using Cedar.
 It shows how to use the Cedar Java API to evaluate a simple policy. You can look at the gradle files to see how to build CedarJava in your own Java applications.
 
-## Usage
+## Build
 
-The Java example works with the version of Cedar available on Maven, which (at the time of writing) is v3.1.2.
-
-### Build
-
-#### Building with the Maven release
-
-You can switch to the cedar-java uber jar in `build.gradle` so that the example runs using both the CedarJava and
-CedarJavaFFI libraries from the Maven release of cedar-java:3.1.2.
+### Building with the Maven release
+The Java example works with the version of Cedar available on Maven, which (at the time of writing) is v3.1.2. We specify the
+uber jar in build.gradle so that both the CedarJava and CedarJavaFFI libraries are included.
 
 ```shell
-# Change the build.gradle to use the uber jar
-sed -i '' "s/'com.cedarpolicy:cedar-java:3.1.2'/'com.cedarpolicy:cedar-java:3.1.2:uber'/" build.gradle
 ./gradlew build
 ```
 
-#### Building locally
+### Building locally
 
 To build locally, pull the corresponding 3.2.x release of cedar-java and build both CedarJavaFFI and CedarJava in your workspace.
 You will need to ensure that CedarJava is able to find the dynamic library of Cedar. To do that, you need to ensure the

--- a/cedar-java-hello-world/build.gradle
+++ b/cedar-java-hello-world/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     implementation 'com.google.code.findbugs:findbugs:3.0.1'
     implementation 'org.apache.logging.log4j:log4j-core:2.20.0'
     implementation 'org.apache.logging.log4j:log4j-to-slf4j:2.20.0'
-    implementation 'com.cedarpolicy:cedar-java:2.3.3'
+    implementation 'com.cedarpolicy:cedar-java:3.1.2'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.3'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.3'

--- a/cedar-java-hello-world/build.gradle
+++ b/cedar-java-hello-world/build.gradle
@@ -73,6 +73,7 @@ dependencies {
     implementation 'org.slf4j:slf4j-api:2.0.7'
     implementation 'org.apache.commons:commons-text:1.10.0'
     implementation 'com.google.code.findbugs:findbugs:3.0.1'
+    implementation 'com.google.guava:guava:33.1.0-jre'
     implementation 'org.apache.logging.log4j:log4j-core:2.20.0'
     implementation 'org.apache.logging.log4j:log4j-to-slf4j:2.20.0'
     implementation 'com.cedarpolicy:cedar-java:3.1.2'

--- a/cedar-java-hello-world/build.gradle
+++ b/cedar-java-hello-world/build.gradle
@@ -76,7 +76,7 @@ dependencies {
     implementation 'com.google.guava:guava:33.1.0-jre'
     implementation 'org.apache.logging.log4j:log4j-core:2.20.0'
     implementation 'org.apache.logging.log4j:log4j-to-slf4j:2.20.0'
-    implementation 'com.cedarpolicy:cedar-java:3.1.2'
+    implementation 'com.cedarpolicy:cedar-java:3.1.2:uber'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.3'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.3'

--- a/cedar-java-hello-world/src/test/java/samplelib/SampleJavaClassTest.java
+++ b/cedar-java-hello-world/src/test/java/samplelib/SampleJavaClassTest.java
@@ -31,11 +31,11 @@ public class SampleJavaClassTest {
     @Test
     public void sampleMethodTest() {
         SampleJavaClass sampleClass = new SampleJavaClass();
-	try {
-        assertEquals(true, sampleClass.sampleMethod());
-	} catch (AuthException e) {
-		fail("Auth Exception: " + e.toString());
-	}
+        try {
+            assertEquals(true, sampleClass.sampleMethod());
+        } catch (AuthException e) {
+            fail("Auth Exception: " + e.toString());
+        }
     }
 
     @Test
@@ -44,9 +44,8 @@ public class SampleJavaClassTest {
         try {
             sampleClass.shouldFail();
         } catch (AuthException e) {
-            assertEquals(e.toString(), "Auth Exception: Bad request: couldn't parse policy with id p2\nunexpected token `a`: ");
+            assertEquals("Auth Exception: Bad request: couldn't parse policy with id `p2`\nunexpected token `a`: ", e.toString());
         }
-
     }
 
 }


### PR DESCRIPTION
https://github.com/cedar-policy/cedar-examples/issues/168

## build_java_hello_world_reusable.yml
* Adding `build_java_hello_world_reusable.yml`, ~~which I expect will not be evaluated for this PR, but subsequent PRs after this is merged~~.
  * In my fork, I tested this worked by introducing this file in the CI, drafting a PR from a sample branch/commit, and verifying the workflow passed.
## ci.yml
* Updated to use build_java_hello_world_reusable.yml
## README.md
* Updated instructions and wording
  * Do we need to update older revisions?
## build.gradle
* Setting to use the appropriate [Maven](https://central.sonatype.com/artifact/com.cedarpolicy/cedar-java) CedarJava version, `3.1.2`
## SampleJavaClass.java
* Updated source to use CedarJava `3.1.2`
## SampleJavaClassTest.java
* Indentation fixes and fixed assertEquals order