### PR TITLE
Adding manual cedar-java build to CI for java hello world example

### DIFF
--- a/.github/workflows/build_java_hello_world_reusable.yml
+++ b/.github/workflows/build_java_hello_world_reusable.yml
@@ -23,6 +23,10 @@ jobs:
         with:
           distribution: 'corretto'
           java-version: '17'
+      - name: Setup Zig
+        uses: goto-bus-stop/setup-zig@v2.2.0
+        with:
+          version: 0.11.0
       - name: Checkout cedar-examples
         uses: actions/checkout@v4
         with:
@@ -39,6 +43,13 @@ jobs:
       - name: Build CedarJavaFFI
         working-directory: ./cedar-java-hello-world/cedar-java/CedarJavaFFI
         run: cargo build
+      - name: Build CedarJava
+        working-directory: ./cedar-java-hello-world/cedar-java/CedarJava
+        run: ./gradlew build
+      - name: Replace Maven version with Github version
+        working-directory: ./cedar-java-hello-world
+        run: |
+          sed -i "s/'com.cedarpolicy:cedar-java:.*/files('cedar-java\/CedarJava\/build\/libs\/CedarJava.jar')/" build.gradle
       - name: Build cedar-java-hello-world
         working-directory: ./cedar-java-hello-world
         run: bash config.sh && ./gradlew build


### PR DESCRIPTION
https://github.com/cedar-policy/cedar-examples/issues/168

# build_java_hello_world_reusable.yml

* Made changes to build cedar-java locally in CI when building the java hello world example.