### PR TITLE
fix wasm test

### DIFF
--- a/cedar-wasm-example/__tests__/main.test.ts
+++ b/cedar-wasm-example/__tests__/main.test.ts
@@ -105,20 +105,18 @@ describe('Authorizer tests', () => {
             resource: { type: 'App::Code', id: 'this' },
             context: {},
             schema: {
-                json: {
-                    App: {
-                        entityTypes: {
-                            User: {
-                                shape: { type: 'Record', attributes: {} },
-                                memberOfTypes: [],
-                            },
-                            Code: {
-                                shape: { type: 'Record', attributes: {} },
-                                memberOfTypes: [],
-                            },
+                App: {
+                    entityTypes: {
+                        User: {
+                            shape: { type: 'Record', attributes: {} },
+                            memberOfTypes: [],
                         },
-                        actions: {}
-                    }
+                        Code: {
+                            shape: { type: 'Record', attributes: {} },
+                            memberOfTypes: [],
+                        },
+                    },
+                    actions: {}
                 }
             },
             policies: {

--- a/cedar-wasm-example/package-lock.json
+++ b/cedar-wasm-example/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "cedar-wasm-example",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "Apache-2.0",
       "dependencies": {
         "@cedar-policy/cedar-wasm": "3.2.3"
       },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Fix a syntax issue in one of the wasm tests, now caught due to [cedar#1075](https://github.com/cedar-policy/cedar/pull/1075)
* Fix license in the lock file (this change will be made automatically if you run `npm i`)