### PR TITLE
Simplify the document cloud example

### DIFF
--- a/cedar-example-use-cases/document_cloud/ALLOW/alice_create_authenticated.json
+++ b/cedar-example-use-cases/document_cloud/ALLOW/alice_create_authenticated.json
@@ -1,6 +1,6 @@
 {
     "principal": "User::\"alice\"",
-    "action": "Action::\"CreateDocument\"",
+    "action": "Action::\"createDocument\"",
     "resource": "Drive::\"drive\"",
-    "context": {"is_authenticated": true}
+    "context": {}
 }

--- a/cedar-example-use-cases/document_cloud/ALLOW/alice_view_alice_public.json
+++ b/cedar-example-use-cases/document_cloud/ALLOW/alice_view_alice_public.json
@@ -1,6 +1,6 @@
 {
     "principal": "User::\"alice\"",
-    "action": "Action::\"ViewDocument\"",
+    "action": "Action::\"viewDocument\"",
     "resource": "Document::\"alice_public\"",
-    "context": {"is_authenticated": true}
+    "context": {}
 }

--- a/cedar-example-use-cases/document_cloud/ALLOW/charlie_view_alice_public.json
+++ b/cedar-example-use-cases/document_cloud/ALLOW/charlie_view_alice_public.json
@@ -1,6 +1,6 @@
 {
     "principal": "User::\"charlie\"",
-    "action": "Action::\"ViewDocument\"",
+    "action": "Action::\"viewDocument\"",
     "resource": "Document::\"alice_public\"",
-    "context": {"is_authenticated": true}
+    "context": {}
 }

--- a/cedar-example-use-cases/document_cloud/DENY/alice_create_unauthenticated.json
+++ b/cedar-example-use-cases/document_cloud/DENY/alice_create_unauthenticated.json
@@ -1,6 +1,0 @@
-{
-    "principal": "User::\"alice\"",
-    "action": "Action::\"CreateDocument\"",
-    "resource": "Drive::\"drive\"",
-    "context": {"is_authenticated": false}
-}

--- a/cedar-example-use-cases/document_cloud/DENY/bob_view_alice_public.json
+++ b/cedar-example-use-cases/document_cloud/DENY/bob_view_alice_public.json
@@ -1,6 +1,6 @@
 {
     "principal": "User::\"bob\"",
-    "action": "Action::\"ViewDocument\"",
+    "action": "Action::\"viewDocument\"",
     "resource": "Document::\"alice_public\"",
-    "context": {"is_authenticated": true}
+    "context": {}
 }

--- a/cedar-example-use-cases/document_cloud/README.md
+++ b/cedar-example-use-cases/document_cloud/README.md
@@ -15,7 +15,7 @@ For convenience, `User`s can be organized into `Group`s. Documents can be shared
 
 ### `Document`
 
-`Document`s are the core resource of the system. Every document has an owner, which is the `User` who created it. `Document` uses access control lists (ACLs) to manage permissions for action types such as view, edit, and manage.
+`Document`s are the core resource of the system. Every document has an owner, which is the `User` who created it. `Document`s use access control lists (ACLs) to manage permissions for action types such as view, edit, and manage.
 An ACL is modeled as a set of `Group`s. We recommend that you create a "personal" `Group` for each `User`, such that adding a `User` to an ACL amounts to adding the personal `Group` to the set of `Group`s modeling the ACL.
 
 It is always enforced that only the owner can delete or edit the sharing state of a document.
@@ -99,7 +99,7 @@ permit (
 when { resource.owner == principal };
 ```
 
-Any `User` should be able to perform any action on a `Drive`, including `createDocument`.
+Any `User` should be able to perform any action on a `Drive` they own, including `createDocument`.
 
 ### Viewing Documents
 
@@ -126,7 +126,7 @@ permit (
 when { principal in resource.viewACL };
 ```
 
-Any `User` can view a `Document` when it's publicly readable and editable.
+Any `User` can view a `Document` when it's publicly readable or editable.
 
 ```
 @id("public-view")

--- a/cedar-example-use-cases/document_cloud/README.md
+++ b/cedar-example-use-cases/document_cloud/README.md
@@ -1,6 +1,6 @@
 # Document Cloud Drive Use-Case
 
-Envision a cloud-based document sharing system, like Google Drive or Dropbox. This system can be used by a single user, who is working on documents across multiple of their personal computers, by multiple users, who are collaborating on a shared set of documents, or by the public as a hosting solution. Users need to be able upload, delete, and modify the sharing permissions on their documents. Users also need to be able to view, comment on, and and modify documents that they have access to, while the system enforces correct access control logic. Since this is a multi-tenant system, it must be robust to cross-user abuse. This system includes a blocklist feature to prevent that.
+Envision a cloud-based document sharing system, like Google Drive or Dropbox. This system can be used by a single user, who is working on documents across multiple of their personal computers, by multiple users, who are collaborating on a shared set of documents, or by the public as a hosting solution. Users need to be able upload, delete, and modify the sharing permissions on their documents. Users also need to be able to view, comment on, and and modify documents that they have access to, while the system enforces correct access control logic. Since this is a multi-tenant system, it must be robust to cross-user abuse. This system includes a block list feature to prevent that.
 
 We first define the entities involved in this system.
 ## Entities
@@ -8,19 +8,15 @@ We first define the entities involved in this system.
 ### `User`
 `User`s are the main principals of the system. They are the ones who view/edit/delete documents, as well as the ones who control sharing permissions on documents. `User`s may also block other users. For instance, if Alice blocks Bob, then Bob should not be able to view any documents Alice owns, or share anything with Alice.
 
+We assume that all `User`s are authenticated before requesting any authorization.
+
 ### `Group`
 For convenience, `User`s can be organized into `Group`s. Documents can be shared with entire `Group`s at once. We’ll borrow from Unix and say that every `User` also has a `Group` containing only them.
 
-### `Public`
-A principal that represents an un-authenticated user.
-
 ### `Document`
 
-`Document`s are the core resource of the system. Every document has an owner, which is the `User` who created it. Documents have 3 axis of sharing
-
-* Private: only the owner can view/edit/comment/delete the document
-* ACL: List of users/groups that are allowed view, groups allowed to comment, groups allowed to edit, groups allowed to manage.
-* Public: Can the public view/edit/comment on the document
+`Document`s are the core resource of the system. Every document has an owner, which is the `User` who created it. `Document` uses access control lists (ACLs) to manage permissions for action types such as view, edit, and manage.
+An ACL is modeled as a `Group`.
 
 It is always enforced that only the owner can delete or edit the sharing state of a document
 
@@ -28,17 +24,14 @@ Next we define the actions that principals can perform.
 
 ## Actions
 
-* `CreateDocument`: Create a new document in the system. Any authenticated user can do this.
-* `ViewDocument`: Must pass ACL check
-* `DeleteDocument`: Only the owner should be able do this.
-* `CommentOnDocument`: Must pass ACL check
-* `ModifyDocument`: Must pass ACL check
-* `EditIsPrivate`: Only the owner can do this
-* `AddToShareACL`: Anyone who has manage access can do this. The owner can never have their access be revoked.
-* `EditPublic`: Anyone who has edit access can do this.
-* `CreateGroup`: Any authenticated user can do this
-* `ModifyGroup`: Only the owner of the group can do this
-* `DeleteGroup`: Only the owner of the group can do this
+* `createDocument`: Create a new document in the system.
+* `viewDocument`: View a document.
+* `deleteDocument`: Delete a document.
+* `modifyDocument`: Modify a document.
+* `addToShareACL`: Share a document.
+* `createGroup`: Create a group.
+* `modifyGroup`: Modify a group.
+* `deleteGroup`: Delete a group.
 
 
 Let’s take this and turn it into a concrete schema:
@@ -47,69 +40,47 @@ Let’s take this and turn it into a concrete schema:
 
 * `User`
     * attributes
-        * `personalGroup` a EUID of type `Group`, links to the group containing exactly this user
         * `blocked` a set of EUIDs of type `User`.
     * memberOf: `Group`, can be a member of any group. 
-    * Invariants: 
-        * for any `User` `u`, `u in u.personalGroup` should always be true
-            * as well as `u == u.personalGroup.owner`
 * `Group`
     * attributes:
         * `owner`: a EUID of type `User`, denoting who can manage this group
-    * memberOf: `DocumentShare`
 * `Document`
     * attributes:
         * `owner` an EUID of type `User`
-        * `isPrivate` a boolean
         * `publicAccess` a string, one of: `none`, `view`, or `edit`
-        * `viewACL` an EUID of type `DocumentShare`
-        * `modifyACL` an EUID of type `DocumentShare`
-        * `manageACL` an EUID of type `DocumentShare`
-* `DocumentShare`
-    * A group-entity. All children of this entity are `group`s that are allowed to perform some action on a document
-* `Public`
-    * There is exactly one instance of `public` that represents the un-authenticated user.
-    * memberOf: `DocumentShare`
+        * `viewACL` an EUID of type `Group`
+        * `modifyACL` an EUID of type `Group`
+        * `manageACL` an EUID of type `Group`
 * `Drive`
     * A “container entity” that represents the entire application.
 
 ### Action Types
 
-* `CreateDocument`: Create a new document in the system. Any authenticated user can do this.
+* `createDocument`: Create a new document in the system. Any authenticated user can do this.
     * principals: `User`
     * resources: `Drive`
-* `ViewDocument`: Must pass ACL check
+* `viewDocument`: Must pass ACL check
     * principals: `User`
     * resources: `Document`
-* `DeleteDocument`: Only the owner should be able do this.
+* `deleteDocument`: Only the owner should be able do this.
     * principals: `User`
     * resources: `Document`
-* `ModifyDocument`: Must pass ACL check
+* `modifyDocument`: Must pass ACL check
     * principals: `User`
     * resources: `Document`
-* `EditIsPrivate`: Only the owner can do this
+* `addToShareACL`: Anyone who has manage access can do this. The owner can never have their access be revoked.
     * principals: `User`
     * resources: `Document`
-* `AddToShareACL`: Anyone who has manage access can do this. The owner can never have their access be revoked.
-    * principals: `User`
-    * resources: `Document`
-* `EditPublicAccess`: Anyone who has manage access can do this.
-    * principals: `User`
-    * resources: `Document`
-* `CreateGroup`: Any authenticated user can do this
+* `createGroup`: Any authenticated user can do this
     * principals: `User`
     * resources: `Drive`
-* `ModifyGroup`: Only the owner of the group can do this
+* `modifyGroup`: Only the owner of the group can do this
     * principals: `User`
     * resources: `Group`
-* `DeleteGroup`: Only the owner of the group can do this
+* `deleteGroup`: Only the owner of the group can do this
     * principals: `User`
     * resources: `Group`
-
-## Context
-
-* `is_authenticated`: Whether or not the request is from an authenticated user
-    * type: `Boolean`
 
 
 Finally, let's look at the policies for permission management.
@@ -119,135 +90,104 @@ Finally, let's look at the policies for permission management.
 
 
 ```
+@id("drive-owner")
 permit (
-  principal,
-  action == Action::"CreateDocument",
-  resource == Drive::"drive"
-);
+    principal,
+    action,
+    resource is Drive
+)
+when { resource.owner == principal };
 ```
 
-Any authenticated user should be able to make a document. Since the only valid principal-type here is `User`, this accomplishes that. However, the “authenticated” part isn’t anywhere *in* the policy, and isn’t checked at runtime.
-There are a couple of solutions here:
-
-1. Create an entity `Users::"AllUsers"` that every user is a part of. This makes the graph rather big, but maybe we don’t care.
-2. An `is` operator, ex: `principal is User`
-3. Runtime enforcement of action types.
+Any `User` should be able to perform any action on a `Drive`, including `createDocument`.
 
 ### Viewing Documents
 
-The owner should always be able to view the document.
-
+The owner should always be able to perform any action on a `Document`, including `viewDocument`.
 ```
+@id("document-owner")
 permit (
-  principal,
-  action == Action::"ViewDocument",
-  resource
+    principal,
+    action,
+    resource is Document
 )
 when { principal == resource.owner };
 ```
 
-Anyone who is in the view ACL should be able to view the document, when it’s not private
+Anyone who is in the view ACL should be able to view the document
 
 ```
+@id("viewACL")
 permit (
-  principal,
-  action == Action::"ViewDocument",
-  resource
+    principal,
+    action == Action::"viewDocument",
+    resource
 )
-when { principal in resource.viewACL }
-unless { resource.isPrivate };
+when { principal in resource.viewACL };
 ```
 
-An un-authenticated principal can view only when explicitly permitted
+Any `User` can view a `Document` when it's publicly readable and editable.
 
 ```
+@id("public-view")
 permit (
-  principal == Public::"public",
-  action == Action::"ViewDocument",
-  resource
+    principal,
+    action == Action::"viewDocument",
+    resource
 )
-when { resource.publicAccess == "view" || resource.publicAccess == "edit" }
-unless { resource.isPrivate };
+when { resource.publicAccess == "view" || resource.publicAccess == "edit" };
 ```
 
 ### Delete Document
 
-Simiarly, only the owner can do this
-
-```
-permit (
-  principal,
-  action == Action::"deleteDocument",
-  resource
-)
-when { principal == resource.owner };
-```
+Only the owner can perform this action, indicated by the policy with annotation `id@("document-owner")`.
 
 ### Modify Document
 
 Very similar to viewing, just different ACL:
 
 ```
+@id("modifyACL")
 permit (
-  principal,
-  action == Action::"ModifyDocument",
-  resource
+    principal,
+    action == Action::"modifyDocument",
+    resource
 )
-when { principal == resource.owner };
+when { principal in resource.modifyACL };
 
+@id("public-edit")
 permit (
-  principal,
-  action == Action::"ModifyDocument",
-  resource
+    principal,
+    action == Action::"modifyDocument",
+    resource
 )
-when { principal in resource.modifyACL }
-unless { resource.isPrivate };
-
-permit (
-  principal == Public::"public",
-  action == Action::"ViewDocument",
-  resource
-)
-when { resource.publicAccess == "edit" }
-unless { resource.isPrivate };
+when { resource.publicAccess == "edit" };
 ```
 
 ### Document Management
 
+A `User` can share a `Document` if they are in the `manageACL` group.
 ```
+@id("manageACL")
 permit (
-  principal,
-  action in
-    [Action::"EditIsPrivate",
-     Action::"AddToShareACL",
-     Action::"EditPublicAccess"],
-  resource
-)
-when { principal == resource.owner };
-
-permit (
-  principal,
-  action in [Action::"AddToShareACL", Action::"EditPublicAccess"],
-  resource
+    principal,
+    action in Action::"addToShareACL",
+    resource
 )
 when { principal in resource.manageACL };
 ```
 
 ### Group Management
 
+Similar to `createDocument`, any `User` can perform group management actions as long as they own the group.
 ```
+@id("group-owner")
 permit (
-  principal,
-  action == Action::"CreateGroup",
-  resource == Drive::"drive"
-);
-
-permit (
-  principal,
-  action in [Action::"ModifyGroup", Action::"DeleteGroup"],
-  resource
+    principal,
+    action,
+    resource is Group
 )
-when { principal == resource.owner };
+when { resource has owner && principal == resource.owner };
 ```
 
 ### Blocking

--- a/cedar-example-use-cases/document_cloud/entities.json
+++ b/cedar-example-use-cases/document_cloud/entities.json
@@ -5,12 +5,6 @@
             "id": "alice"
         },
         "attrs": {
-            "personalGroup": {
-                "__entity": {
-                    "type": "Group",
-                    "id": "alice_personal"
-                }
-            },
             "blocked": [
                 {
                     "__entity": {
@@ -33,12 +27,6 @@
             "id": "bob"
         },
         "attrs": {
-            "personalGroup": {
-                "__entity": {
-                    "type": "Group",
-                    "id": "bob_personal"
-                }
-            },
             "blocked": []
         },
         "parents": [
@@ -54,12 +42,6 @@
             "id": "charlie"
         },
         "attrs": {
-            "personalGroup": {
-                "__entity": {
-                    "type": "Group",
-                    "id": "charlie_personal"
-                }
-            },
             "blocked": []
         },
         "parents": [
@@ -75,12 +57,6 @@
             "id": "alice_personal"
         },
         "attrs": {
-            "owner": {
-                "__entity": {
-                    "type": "User",
-                    "id": "alice"
-                }
-            }
         },
         "parents": []
     },
@@ -90,19 +66,8 @@
             "id": "bob_personal"
         },
         "attrs": {
-            "owner": {
-                "__entity": {
-                    "type": "User",
-                    "id": "bob"
-                }
-            }
         },
-        "parents": [
-            {
-                "type": "DocumentShare",
-                "id": "alice_public_view"
-            }
-        ]
+        "parents": []
     },
     {
         "uid": {
@@ -110,19 +75,8 @@
             "id": "charlie_personal"
         },
         "attrs": {
-            "owner": {
-                "__entity": {
-                    "type": "User",
-                    "id": "charlie"
-                }
-            }
         },
-        "parents": [
-            {
-                "type": "DocumentShare",
-                "id": "alice_public_view"
-            }
-        ]
+        "parents": []
     },
     {
         "uid": {
@@ -136,59 +90,20 @@
                     "id": "alice"
                 }
             },
-            "isPrivate": false,
             "publicAccess": "view",
-            "viewACL": {
-                "__entity": {
-                    "type": "DocumentShare",
-                    "id": "alice_public_view"
-                }
-            },
-            "modifyACL": {
-                "__entity": {
-                    "type": "Document",
-                    "id": "alice_public_modify"
-                }
-            },
-            "manageACL": {
-                "__entity": {
-                    "type": "Document",
-                    "id": "alice_public_manage"
-                }
-            }
+            "viewACL": [
+                {"__entity": {
+                    "type": "Group",
+                    "id": "bob_personal"
+                }},
+                {"__entity": {
+                    "type": "Group",
+                    "id": "charlie_personal"
+                }}
+            ],
+            "modifyACL": [],
+            "manageACL": []
         },
-        "parents": []
-    },
-    {
-        "uid": {
-            "type": "DocumentShare",
-            "id": "alice_public_view"
-        },
-        "attrs": {},
-        "parents": []
-    },
-    {
-        "uid": {
-            "type": "DocumentShare",
-            "id": "alice_public_modify"
-        },
-        "attrs": {},
-        "parents": []
-    },
-    {
-        "uid": {
-            "type": "DocumentShare",
-            "id": "alice_public_manage"
-        },
-        "attrs": {},
-        "parents": []
-    },
-    {
-        "uid": {
-            "type": "Public",
-            "id": "unauthenticated"
-        },
-        "attrs": {},
         "parents": []
     },
     {
@@ -196,7 +111,14 @@
             "type": "Drive",
             "id": "drive"
         },
-        "attrs": {},
+        "attrs": {
+            "owner": {
+                "__entity": {
+                    "type":"User",
+                    "id":"alice"
+                }
+            }
+        },
         "parents": []
     }
 ]

--- a/cedar-example-use-cases/document_cloud/policies.cedar
+++ b/cedar-example-use-cases/document_cloud/policies.cedar
@@ -70,16 +70,12 @@ permit (
 )
 when { principal in resource.manageACL };
 
-/// Blocked users cannot perform these actions
+/// Blocked users cannot perform any operations to the document
 @id("blocked-users")
 forbid (
     principal,
-    action in
-        [Action::"viewDocument",
-         Action::"modifyDocument",
-         Action::"addToShareACL",
-         Action::"deleteDocument"],
-    resource
+    action,
+    resource is Document
 )
 when
 { resource.owner has blocked && resource.owner.blocked.contains(principal) };

--- a/cedar-example-use-cases/document_cloud/policies.cedar
+++ b/cedar-example-use-cases/document_cloud/policies.cedar
@@ -1,81 +1,81 @@
 /// A drive owner can perform any actions on it
 @id("drive-owner")
 permit (
-    principal,
-    action,
-    resource is Drive
+  principal,
+  action,
+  resource is Drive
 )
 when { resource.owner == principal };
 
 /// A document owner can perform any actions on it
 @id("document-owner")
 permit (
-    principal,
-    action,
-    resource is Document
+  principal,
+  action,
+  resource is Document
 )
 when { principal == resource.owner };
 
 /// A group owner can perform any actions on it
 @id("group-owner")
 permit (
-    principal,
-    action,
-    resource is Group
+  principal,
+  action,
+  resource is Group
 )
 when { resource has owner && principal == resource.owner };
 
 /// Users in the viewACL group can view the document
 @id("viewACL")
 permit (
-    principal,
-    action == Action::"viewDocument",
-    resource
+  principal,
+  action == Action::"viewDocument",
+  resource
 )
 when { principal in resource.viewACL };
 
 /// Any user can view a document when it's publicly accessible
 @id("public-view")
 permit (
-    principal,
-    action == Action::"viewDocument",
-    resource
+  principal,
+  action == Action::"viewDocument",
+  resource
 )
 when { resource.publicAccess == "view" || resource.publicAccess == "edit" };
 
 /// Users in the modifyACL group can modify the document
 @id("modifyACL")
 permit (
-    principal,
-    action == Action::"modifyDocument",
-    resource
+  principal,
+  action == Action::"modifyDocument",
+  resource
 )
 when { principal in resource.modifyACL };
 
 /// Any user can modify a document when it's publicly editable
 @id("public-edit")
 permit (
-    principal,
-    action == Action::"modifyDocument",
-    resource
+  principal,
+  action == Action::"modifyDocument",
+  resource
 )
 when { resource.publicAccess == "edit" };
 
 /// Users in the manageACL group can edit built-in groups
 @id("manageACL")
 permit (
-    principal,
-    action in Action::"addToShareACL",
-    resource
+  principal,
+  action in Action::"addToShareACL",
+  resource
 )
 when { principal in resource.manageACL };
 
 /// Blocked users cannot perform any operations to the document
 @id("blocked-users")
 forbid (
-    principal,
-    action,
-    resource is Document
+  principal,
+  action,
+  resource is Document
 )
 when
 { resource.owner has blocked && resource.owner.blocked.contains(principal) };

--- a/cedar-example-use-cases/document_cloud/policies.cedar
+++ b/cedar-example-use-cases/document_cloud/policies.cedar
@@ -70,7 +70,7 @@ permit (
 )
 when { principal in resource.manageACL };
 
-/// Blacklisted users cannot perform these actions
+/// Blocked users cannot perform these actions
 @id("blocked-users")
 forbid (
     principal,

--- a/cedar-example-use-cases/document_cloud/policies.cedar
+++ b/cedar-example-use-cases/document_cloud/policies.cedar
@@ -23,7 +23,7 @@ permit (
     action,
     resource is Group
 )
-when { principal == resource.owner };
+when { resource has owner && principal == resource.owner };
 
 /// Users in the viewACL group can view the document
 @id("viewACL")
@@ -65,7 +65,7 @@ when { resource.publicAccess == "edit" };
 @id("manageACL")
 permit (
     principal,
-    action in [Action::"addToShareACL", Action::"editPublicAccess"],
+    action in Action::"addToShareACL",
     resource
 )
 when { principal in resource.manageACL };
@@ -78,7 +78,6 @@ forbid (
         [Action::"viewDocument",
          Action::"modifyDocument",
          Action::"addToShareACL",
-         Action::"editPublicAccess",
          Action::"deleteDocument"],
     resource
 )

--- a/cedar-example-use-cases/document_cloud/policies.cedar
+++ b/cedar-example-use-cases/document_cloud/policies.cedar
@@ -34,7 +34,7 @@ permit (
 )
 when { principal in resource.viewACL };
 
-/// Any user can view a document when it's publicly accessable and not private
+/// Any user can view a document when it's publicly accessible and not private
 @id("public-view")
 permit (
     principal,

--- a/cedar-example-use-cases/document_cloud/policies.cedar
+++ b/cedar-example-use-cases/document_cloud/policies.cedar
@@ -1,118 +1,86 @@
+/// A drive owner can perform any actions on it
+@id("drive-owner")
 permit (
-  principal,
-  action == Action::"CreateDocument",
-  resource == Drive::"drive"
-);
+    principal,
+    action,
+    resource is Drive
+)
+when { resource.owner == principal };
 
+/// A document owner can perform any actions on it
+@id("document-owner")
 permit (
-  principal,
-  action == Action::"ViewDocument",
-  resource
+    principal,
+    action,
+    resource is Document
 )
 when { principal == resource.owner };
 
+/// A group owner can perform any actions on it
+@id("group-owner")
 permit (
-  principal,
-  action == Action::"ViewDocument",
-  resource
-)
-when { principal in resource.viewACL }
-unless { resource.isPrivate };
-
-permit (
-  principal == Public::"public",
-  action == Action::"ViewDocument",
-  resource
-)
-when { resource.publicAccess == "view" || resource.publicAccess == "edit" }
-unless { resource.isPrivate };
-
-permit (
-  principal,
-  action == Action::"ViewDocument",
-  resource
+    principal,
+    action,
+    resource is Group
 )
 when { principal == resource.owner };
 
+/// Users in the viewACL group can view the document unless it's private
+@id("viewACL")
 permit (
-  principal,
-  action == Action::"ModifyDocument",
-  resource
+    principal,
+    action == Action::"ViewDocument",
+    resource
 )
-when { principal == resource.owner };
+when { principal in resource.viewACL };
 
+/// Any user can view a document when it's publicly accessable and not private
+@id("public-view")
 permit (
-  principal,
-  action == Action::"ModifyDocument",
-  resource
+    principal,
+    action == Action::"ViewDocument",
+    resource
 )
-when { principal in resource.modifyACL }
-unless { resource.isPrivate };
+when { resource.publicAccess == "view" || resource.publicAccess == "edit" };
 
+/// Users in the modifyACL group can modify the document unless it's private
+@id("modifyACL")
 permit (
-  principal == Public::"public",
-  action == Action::"ViewDocument",
-  resource
+    principal,
+    action == Action::"ModifyDocument",
+    resource
 )
-when { resource.publicAccess == "edit" }
-unless { resource.isPrivate };
+when { principal in resource.modifyACL };
 
+/// Any user can modify a document when it's publicly editable and not private
+@id("public-edit")
 permit (
-  principal,
-  action in
-    [Action::"EditIsPrivate",
-     Action::"AddToShareACL",
-     Action::"EditPublicAccess"],
-  resource
+    principal,
+    action == Action::"ModifyDocument",
+    resource
 )
-when { principal == resource.owner };
+when { resource.publicAccess == "edit" };
 
+/// Users in the manageACL group can edit built-in groups
+@id("manageACL")
 permit (
-  principal,
-  action in [Action::"AddToShareACL", Action::"EditPublicAccess"],
-  resource
+    principal,
+    action in [Action::"AddToShareACL", Action::"EditPublicAccess"],
+    resource
 )
 when { principal in resource.manageACL };
 
-permit (
-  principal,
-  action == Action::"CreateGroup",
-  resource == Drive::"drive"
-);
-
-permit (
-  principal,
-  action in [Action::"ModifyGroup", Action::"DeleteGroup"],
-  resource
-)
-when { principal == resource.owner };
-
+/// Blacklisted users cannot perform these actions
+@id("blocked-users")
 forbid (
-  principal,
-  action in
-    [Action::"ViewDocument",
-     Action::"ModifyDocument",
-     Action::"EditIsPrivate",
-     Action::"AddToShareACL",
-     Action::"EditPublicAccess",
-     Action::"DeleteDocument"],
-  resource
+    principal,
+    action in
+        [Action::"ViewDocument",
+         Action::"ModifyDocument",
+         Action::"AddToShareACL",
+         Action::"EditPublicAccess",
+         Action::"DeleteDocument"],
+    resource
 )
 when
-{
-  principal has blocked &&
-  (resource.owner.blocked.contains(principal) ||
-   principal.blocked.contains(resource.owner))
-};
-
-forbid (principal, action, resource)
-when { !context.is_authenticated };
-
-forbid (principal, action, resource)
-when
-{
-  resource has owner &&
-  principal != resource.owner &&
-  resource has isPrivate &&
-  resource.isPrivate
-};
+{ resource.owner has blocked && resource.owner.blocked.contains(principal) };

--- a/cedar-example-use-cases/document_cloud/policies.cedar
+++ b/cedar-example-use-cases/document_cloud/policies.cedar
@@ -25,38 +25,38 @@ permit (
 )
 when { principal == resource.owner };
 
-/// Users in the viewACL group can view the document unless it's private
+/// Users in the viewACL group can view the document
 @id("viewACL")
 permit (
     principal,
-    action == Action::"ViewDocument",
+    action == Action::"viewDocument",
     resource
 )
 when { principal in resource.viewACL };
 
-/// Any user can view a document when it's publicly accessible and not private
+/// Any user can view a document when it's publicly accessible
 @id("public-view")
 permit (
     principal,
-    action == Action::"ViewDocument",
+    action == Action::"viewDocument",
     resource
 )
 when { resource.publicAccess == "view" || resource.publicAccess == "edit" };
 
-/// Users in the modifyACL group can modify the document unless it's private
+/// Users in the modifyACL group can modify the document
 @id("modifyACL")
 permit (
     principal,
-    action == Action::"ModifyDocument",
+    action == Action::"modifyDocument",
     resource
 )
 when { principal in resource.modifyACL };
 
-/// Any user can modify a document when it's publicly editable and not private
+/// Any user can modify a document when it's publicly editable
 @id("public-edit")
 permit (
     principal,
-    action == Action::"ModifyDocument",
+    action == Action::"modifyDocument",
     resource
 )
 when { resource.publicAccess == "edit" };
@@ -65,7 +65,7 @@ when { resource.publicAccess == "edit" };
 @id("manageACL")
 permit (
     principal,
-    action in [Action::"AddToShareACL", Action::"EditPublicAccess"],
+    action in [Action::"addToShareACL", Action::"editPublicAccess"],
     resource
 )
 when { principal in resource.manageACL };
@@ -75,11 +75,11 @@ when { principal in resource.manageACL };
 forbid (
     principal,
     action in
-        [Action::"ViewDocument",
-         Action::"ModifyDocument",
-         Action::"AddToShareACL",
-         Action::"EditPublicAccess",
-         Action::"DeleteDocument"],
+        [Action::"viewDocument",
+         Action::"modifyDocument",
+         Action::"addToShareACL",
+         Action::"editPublicAccess",
+         Action::"deleteDocument"],
     resource
 )
 when

--- a/cedar-example-use-cases/document_cloud/policies.cedarschema
+++ b/cedar-example-use-cases/document_cloud/policies.cedarschema
@@ -16,27 +16,27 @@ entity User in Group = {
   "personalGroup": Group,
 };
 
-action DeleteGroup, ModifyGroup appliesTo {
+action deleteGroup, modifyGroup appliesTo {
   principal: [User],
   resource: [Group],
 };
-action CreateGroup appliesTo {
+action createGroup appliesTo {
   principal: [User],
   resource: [Drive],
 };
-action ViewDocument appliesTo {
+action viewDocument appliesTo {
   principal: [User],
   resource: [Document],
 };
-action AddToShareACL, DeleteDocument, EditPublicAccess appliesTo {
+action addToShareACL, deleteDocument, editPublicAccess appliesTo {
   principal: [User],
   resource: [Document],
 };
-action ModifyDocument appliesTo {
+action modifyDocument appliesTo {
   principal: [User],
   resource: [Document],
 };
-action CreateDocument appliesTo {
+action createDocument appliesTo {
   principal: [User],
   resource: [Drive],
 };

--- a/cedar-example-use-cases/document_cloud/policies.cedarschema
+++ b/cedar-example-use-cases/document_cloud/policies.cedarschema
@@ -2,41 +2,29 @@ entity Drive {
   owner: User,
 };
 entity Document  = {
-  "manageACL": Group,
-  "modifyACL": Group,
+  "manageACL": Set<Group>,
+  "modifyACL": Set<Group>,
   "owner": User,
   "publicAccess": String,
-  "viewACL": Group,
+  "viewACL": Set<Group>,
 };
 entity Group = {
-  "owner": User,
+  // Absence of the `owner` attribut indicates that it's a personal group.
+  "owner"?: User,
 };
 entity User in Group = {
   blocked?: Set<User>,
-  "personalGroup": Group,
 };
 
 action deleteGroup, modifyGroup appliesTo {
   principal: [User],
   resource: [Group],
 };
-action createGroup appliesTo {
+action createGroup, createDocument appliesTo {
   principal: [User],
   resource: [Drive],
 };
-action viewDocument appliesTo {
+action viewDocument, deleteDocument, modifyDocument, addToShareACL appliesTo {
   principal: [User],
   resource: [Document],
-};
-action addToShareACL, deleteDocument, editPublicAccess appliesTo {
-  principal: [User],
-  resource: [Document],
-};
-action modifyDocument appliesTo {
-  principal: [User],
-  resource: [Document],
-};
-action createDocument appliesTo {
-  principal: [User],
-  resource: [Drive],
 };

--- a/cedar-example-use-cases/document_cloud/policies.cedarschema
+++ b/cedar-example-use-cases/document_cloud/policies.cedarschema
@@ -1,60 +1,42 @@
-entity DocumentShare, Drive;
+entity Drive {
+  owner: User,
+};
 entity Document  = {
-  "isPrivate": Bool,
-  "manageACL": DocumentShare,
-  "modifyACL": DocumentShare,
+  "manageACL": Group,
+  "modifyACL": Group,
   "owner": User,
   "publicAccess": String,
-  "viewACL": DocumentShare,
+  "viewACL": Group,
 };
-entity Group in [DocumentShare] = {
+entity Group = {
   "owner": User,
 };
-entity Public in [DocumentShare];
-entity User in [Group] = {
-  "blocked": Set<User>,
+entity User in Group = {
+  blocked?: Set<User>,
   "personalGroup": Group,
 };
 
 action DeleteGroup, ModifyGroup appliesTo {
   principal: [User],
   resource: [Group],
-  context: {
-    "is_authenticated": Bool,
-  }
 };
 action CreateGroup appliesTo {
   principal: [User],
   resource: [Drive],
-  context: {
-    "is_authenticated": Bool,
-  }
 };
 action ViewDocument appliesTo {
-  principal: [User, Public],
-  resource: [Document],
-  context: {
-    "is_authenticated": Bool,
-  }
-};
-action AddToShareACL, DeleteDocument, EditIsPrivate, EditPublicAccess appliesTo {
   principal: [User],
   resource: [Document],
-  context: {
-    "is_authenticated": Bool,
-  }
+};
+action AddToShareACL, DeleteDocument, EditPublicAccess appliesTo {
+  principal: [User],
+  resource: [Document],
 };
 action ModifyDocument appliesTo {
   principal: [User],
   resource: [Document],
-  context: {
-    "is_authenticated": Bool,
-  }
 };
 action CreateDocument appliesTo {
   principal: [User],
   resource: [Drive],
-  context: {
-    "is_authenticated": Bool,
-  }
 };

--- a/cedar-example-use-cases/document_cloud/policies.cedarschema
+++ b/cedar-example-use-cases/document_cloud/policies.cedarschema
@@ -2,15 +2,15 @@ entity Drive {
   owner: User,
 };
 entity Document  = {
-  "manageACL": Set<Group>,
-  "modifyACL": Set<Group>,
-  "owner": User,
-  "publicAccess": String,
-  "viewACL": Set<Group>,
+  manageACL: Set<Group>,
+  modifyACL: Set<Group>,
+  owner: User,
+  publicAccess: String,
+  viewACL: Set<Group>,
 };
 entity Group = {
-  // Absence of the `owner` attribut indicates that it's a personal group.
-  "owner"?: User,
+  // Absence of the `owner` attribute indicates that it's a personal group.
+  owner?: User,
 };
 entity User in Group = {
   blocked?: Set<User>,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR simplifies the original model as follows.

1. Remove `is_authenticated` attribute from context. Now we assume each user is authenticated before requesting authorization.
2. Remove `Public` entity type. I think it should amount to unconstrained principal.
3. Remove `DocumentShare` entity type. It appears to me that `Group` is all we need, provided that we remove the `Public` type.
4. Remove `isPrivate` attribute. My rationale is that it can conflict with the `public_access` attribute.
5. Merge certain policies into a single policy.
6. Remove two forbid policies using stale attributes.
7. Revise the remaining policy such that only resource owner's blocked list takes effects.