### PR TITLE
fix 3.3 build

### DIFF
--- a/cedar-java-hello-world/README.md
+++ b/cedar-java-hello-world/README.md
@@ -15,12 +15,12 @@ uber jar in build.gradle so that both the CedarJava and CedarJavaFFI libraries a
 
 ### Building locally
 
-To build locally, pull the corresponding 3.2.x release of cedar-java and build both CedarJavaFFI and CedarJava in your workspace.
+To build locally, pull the corresponding 3.3.x release of cedar-java and build both CedarJavaFFI and CedarJava in your workspace.
 You will need to ensure that CedarJava is able to find the dynamic library of Cedar. To do that, you need to ensure the
 environment variable `CEDAR_JAVA_FFI_LIB` gives the location of your `cedar_java_ffi` shared library. Typically this can be done by running `config.sh`:
 
 ```shell
-git clone -b release/3.2.x https://github.com/cedar-policy/cedar-java.git
+git clone -b release/3.3.x https://github.com/cedar-policy/cedar-java.git
 cd cedar-java/CedarJavaFFI && cargo build
 cd ../CedarJava && ./gradlew build
 # Change the build.gradle to reference the jar built locally in the step above

--- a/cedar-rust-hello-world/Cargo.toml
+++ b/cedar-rust-hello-world/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 serde_json = "1.0"
 
 [dependencies.cedar-policy]
-version = "3.2.0"
+version = "3.3.0"

--- a/cedar-wasm-example/package.json
+++ b/cedar-wasm-example/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cedar-policy/cedar-wasm": "3.2.3"
+    "@cedar-policy/cedar-wasm": "3.2.4"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",

--- a/oopsla2024-benchmarks/src/apps.rs
+++ b/oopsla2024-benchmarks/src/apps.rs
@@ -231,7 +231,7 @@ impl ExampleApp {
 
     /// Create a `GeneratorSchema` from the given filepath
     pub fn load_schema(path: impl AsRef<Path>, u: &mut Unstructured<'_>) -> GeneratorSchema {
-        let schema = SchemaFragment::from_json_file(File::open(path.as_ref()).unwrap_or_else(|e| {
+        let schema = SchemaFragment::from_file(File::open(path.as_ref()).unwrap_or_else(|e| {
             panic!(
                 "failed to open schema file {}: {e}",
                 path.as_ref().display()

--- a/oopsla2024-benchmarks/src/apps.rs
+++ b/oopsla2024-benchmarks/src/apps.rs
@@ -231,7 +231,7 @@ impl ExampleApp {
 
     /// Create a `GeneratorSchema` from the given filepath
     pub fn load_schema(path: impl AsRef<Path>, u: &mut Unstructured<'_>) -> GeneratorSchema {
-        let schema = SchemaFragment::from_file(File::open(path.as_ref()).unwrap_or_else(|e| {
+        let schema = SchemaFragment::from_json_file(File::open(path.as_ref()).unwrap_or_else(|e| {
             panic!(
                 "failed to open schema file {}: {e}",
                 path.as_ref().display()

--- a/tinytodo/Cargo.toml
+++ b/tinytodo/Cargo.toml
@@ -21,7 +21,7 @@ notify = { version = "5.1.0", default-features = false, features = ["macos_kqueu
 use-templates = []
 
 [dependencies.cedar-policy]
-version = "3.2.0"
+version = "3.3.0"
 git = "https://github.com/cedar-policy/cedar"
-branch = "release/3.2.x"
+branch = "release/3.3.x"
 #Do not add any lines below this. CI relies on the previous line being the second-to-last line in the file

--- a/tinytodo/TUTORIAL.md
+++ b/tinytodo/TUTORIAL.md
@@ -488,7 +488,7 @@ pub fn spawn(
 ) -> std::result::Result<Sender<AppQuery>, ContextError> {
     ...
     let schema_file = std::fs::File::open(&schema_path)?;
-    let schema = Schema::from_file(schema_file)?;
+    let schema = Schema::from_json_file(schema_file)?;
     ...
     let policy_src = std::fs::read_to_string(&policies_path)?;
     let policies0 = policy_src.parse()?;

--- a/tinytodo/src/context.rs
+++ b/tinytodo/src/context.rs
@@ -301,7 +301,7 @@ impl AppContext {
         let schema_path = schema_path.into();
         let policies_path = policies_path.into();
         let schema_file = std::fs::File::open(&schema_path)?;
-        let (schema, _) = Schema::from_cedarschema_str(schema_file)?;
+        let (schema, _) = Schema::from_cedarschema_file(schema_file)?;
 
         let entities_file = std::fs::File::open(entities_path.into())?;
         let entities = serde_json::from_reader(entities_file)?;

--- a/tinytodo/src/context.rs
+++ b/tinytodo/src/context.rs
@@ -301,7 +301,7 @@ impl AppContext {
         let schema_path = schema_path.into();
         let policies_path = policies_path.into();
         let schema_file = std::fs::File::open(&schema_path)?;
-        let (schema, _) = Schema::from_file_natural(schema_file)?;
+        let (schema, _) = Schema::from_cedarschema_str(schema_file)?;
 
         let entities_file = std::fs::File::open(entities_path.into())?;
         let entities = serde_json::from_reader(entities_file)?;


### PR DESCRIPTION
*Description of changes:*

Switch to using non-deprecated APIs. Also add version bumps to the relevant build instructions. (Still a little awkward though, since the latest Java release is 3.1.2, the latest Wasm release is 3.2.4, and the OOPSLA folder is pinned to 3.0.1.)

