### PR TITLE
bump wasm version to 3.3

### DIFF
--- a/cedar-wasm-example/package-lock.json
+++ b/cedar-wasm-example/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cedar-policy/cedar-wasm": "3.2.3"
+        "@cedar-policy/cedar-wasm": "3.3.0"
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",
@@ -589,9 +589,10 @@
       "dev": true
     },
     "node_modules/@cedar-policy/cedar-wasm": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@cedar-policy/cedar-wasm/-/cedar-wasm-3.2.3.tgz",
-      "integrity": "sha512-DPtI9SRSFYdrpkL8yKtcseQkZFfd0G0nihSQXMKT63AbENKnMIT/GZE0kiFudl9UT2DsfAyru9ZPfP8y4FK36g=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@cedar-policy/cedar-wasm/-/cedar-wasm-3.3.0.tgz",
+      "integrity": "sha512-slbm/8ijL23Gzz7o9IDZuSZA98cPd5QvcuAFjYK4ICXB1la1XSnUHY24jYIBPci0qfenAFfZG/6vCROR2NMByA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",

--- a/cedar-wasm-example/package.json
+++ b/cedar-wasm-example/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cedar-policy/cedar-wasm": "3.2.4"
+    "@cedar-policy/cedar-wasm": "3.3.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Nit: bumping the Wasm version to 3.3 on the `release/3.3.x` branch. Our CI [already does this](https://github.com/cedar-policy/cedar-examples/blob/01826aaabd14819cb2f228f91fcdd23d47708d3a/.github/workflows/build_wasm_example_reusable.yml#L42), but the old version number will be confusing for people using this example as a reference.

