### PR TITLE
Fixed issue with GitHub action breaking CI for cedar

### DIFF
--- a/.github/workflows/run_example_use_cases_reusable.yml
+++ b/.github/workflows/run_example_use_cases_reusable.yml
@@ -30,7 +30,7 @@ jobs:
           ref: ${{ inputs.cedar_policy_ref }}
           path: ./cedar
       - name: protoc
-      - run: sudo apt-get install protobuf-compiler
+        run: sudo apt-get install protobuf-compiler
       - name: rustup
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - name: Build cli


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes issue with GitHub action breaking CI for cedar. This should fix this failing run: https://github.com/cedar-policy/cedar/actions/runs/13419762983