### PR TITLE
cleanup and fix cedar-java-partial-evaluation

### DIFF
--- a/cedar-java-partial-evaluation/app/src/main/java/cedarjavapoc_partialeval/Launcher.java
+++ b/cedar-java-partial-evaluation/app/src/main/java/cedarjavapoc_partialeval/Launcher.java
@@ -18,16 +18,9 @@ package cedarjavapoc_partialeval;
 import org.apache.log4j.Logger;
 import org.apache.log4j.Level;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
-import com.cedarpolicy.value.PrimBool;
 import com.cedarpolicy.value.Value;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import java.nio.channels.AcceptPendingException;
 
 import org.apache.log4j.BasicConfigurator;
 

--- a/cedar-java-partial-evaluation/app/src/main/resources/policies.cedar
+++ b/cedar-java-partial-evaluation/app/src/main/resources/policies.cedar
@@ -98,18 +98,14 @@ permit(
     principal == User::"John_customer",
     action == Action::"Read",
     resource == Document::"protected_doc1"
-) when {
-    context.authenticated == true
-};
+);
 
 @id("policy13")
 permit(
     principal == User::"Mark_customer",
     action == Action::"Read",
     resource == Document::"protected_doc2"
-) when {
-    context.authenticated == true
-};
+);
 
 @id("policy14")
 permit(

--- a/cedar-java-partial-evaluation/app/src/test/java/cedarjavapoc_partialeval/SampleAuthorizationAppTests.java
+++ b/cedar-java-partial-evaluation/app/src/test/java/cedarjavapoc_partialeval/SampleAuthorizationAppTests.java
@@ -13,22 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package cedarjavapoc_partialeval;
+
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
 import static org.junit.jupiter.api.Assertions.*;
-import cedarjavapoc_partialeval.SampleAuthorizationApp;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.cedarpolicy.model.exception.AuthException;
 import com.cedarpolicy.model.exception.InternalException;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import java.util.Set;
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.HashSet;
 import com.cedarpolicy.model.AuthorizationSuccessResponse.Decision;
 
 public class SampleAuthorizationAppTests {


### PR DESCRIPTION
* SampleAuthorizationAppTests failed to run due to missing package name declaration
* Removed context.authenticated for Read actions in policies.cedar (to be valid as defined in sampleapp.cedarschema)
* Cleaned up unused imports