### PR TITLE
Update the streaming service example

### DIFF
--- a/cedar-example-use-cases/streaming_service/ALLOW/alice_rent_oscar_movie.json
+++ b/cedar-example-use-cases/streaming_service/ALLOW/alice_rent_oscar_movie.json
@@ -4,7 +4,7 @@
     "resource": "Movie::\"Devilish\"",
     "context": {
         "now": {
-            "timestamp" : {
+            "datetime" : {
                 "fn": "datetime",
                 "arg": "2025-02-20T13:00:00-0500"
             }

--- a/cedar-example-use-cases/streaming_service/ALLOW/alice_watch_show.json
+++ b/cedar-example-use-cases/streaming_service/ALLOW/alice_watch_show.json
@@ -4,7 +4,7 @@
     "resource": "Show::\"Buddies\"",
     "context": {
         "now": {
-            "timestamp" : {
+            "datetime" : {
                 "fn": "datetime",
                 "arg": "2025-02-20T13:00:00-0500"
             }

--- a/cedar-example-use-cases/streaming_service/ALLOW/bob_watch_free_movie.json
+++ b/cedar-example-use-cases/streaming_service/ALLOW/bob_watch_free_movie.json
@@ -4,7 +4,7 @@
     "resource": "Movie::\"The Godparent\"",
     "context": {
         "now": {
-            "timestamp" : {
+            "datetime" : {
                 "fn": "datetime",
                 "arg": "2025-02-20T13:00:00-0500"
             }

--- a/cedar-example-use-cases/streaming_service/ALLOW/dave_watch_after_early_access.json
+++ b/cedar-example-use-cases/streaming_service/ALLOW/dave_watch_after_early_access.json
@@ -1,12 +1,12 @@
 {
-    "principal": "Subscriber::\"Charlie\"",
+    "principal": "Subscriber::\"Dave\"",
     "action": "Action::\"watch\"",
     "resource": "Show::\"Breach\"",
     "context": {
         "now": {
             "datetime" : {
                 "fn": "datetime",
-                "arg": "2025-02-20T13:00:00-0500"
+                "arg": "2025-02-22T13:00:00-0500"
             }
         }
     }

--- a/cedar-example-use-cases/streaming_service/DENY/alice_watch_early_access_show.json
+++ b/cedar-example-use-cases/streaming_service/DENY/alice_watch_early_access_show.json
@@ -1,5 +1,5 @@
 {
-    "principal": "Subscriber::\"Charlie\"",
+    "principal": "Subscriber::\"Alice\"",
     "action": "Action::\"watch\"",
     "resource": "Show::\"Breach\"",
     "context": {

--- a/cedar-example-use-cases/streaming_service/DENY/bob_watch_paid_movie.json
+++ b/cedar-example-use-cases/streaming_service/DENY/bob_watch_paid_movie.json
@@ -4,7 +4,7 @@
     "resource": "Movie::\"The Gleaming\"",
     "context": {
         "now": {
-            "timestamp" : {
+            "datetime" : {
                 "fn": "datetime",
                 "arg": "2025-02-20T13:00:00-0500"
             }

--- a/cedar-example-use-cases/streaming_service/DENY/dave_watch_bedtime_show.json
+++ b/cedar-example-use-cases/streaming_service/DENY/dave_watch_bedtime_show.json
@@ -4,7 +4,7 @@
     "resource": "Show::\"Buddies\"",
     "context": {
         "now": {
-            "timestamp" : {
+            "datetime" : {
                 "fn": "datetime",
                 "arg": "2025-02-20T22:00:00Z"
             }

--- a/cedar-example-use-cases/streaming_service/README.md
+++ b/cedar-example-use-cases/streaming_service/README.md
@@ -14,7 +14,7 @@ There are three main rules to grant access to content:
 
 The other three rules require the `datetime` extension to be encoded:
  - `rent-buy-oscar-movie`: Offers to *Rent or Buy* `Movie`s nominated to the Oscars during the month before the Oscars night. Makes use of the
- `datetime` constructor to build timestamps from datetime strings and compare against the current date and time.
+ `datetime` constructor to build `datetime` values from datetime strings and compare against the current date and time.
  - `early-access-show`: Offers *Early Access* to watch `Show`s 24 hours before the official release date. Makes use of the `duration` constructor and the `offset` method to compare against release dates.
  - `forbid-bedtime-watch-kid-profile`: Forbids access to watch any content to kid profiles during bedtime. Makes use of the `duration` constructor and the `toTime` method to compare against the current time.
 
@@ -24,13 +24,15 @@ The test setup defines the following entities, in `entities.json`:
  - Members: `Alice`, `Charlie` and `Dave` are `Subscribers`. `Bob` is a `FreeMember`. Only `Charlie` pays for the `premium` tier. The kid profile is enabled on `Dave`'s account.
  - Content: `The Godparent`, `The Gleaming`, `Devilish` are `Movie`s. `The Godparent` can be watched for free and was nominated to the Oscars. `Devilish` is also nominated to the Oscars. `Buddies` and `Breach` are `Show`s. `Breach` will be released on `2025-02-21` and available for *Early Access*.
 
-We have created six scenarios.
-Note that all requests except the last one use the same time: `2025-02-20T13:00:00-0500` (EST timezone offset).
+We have created eight scenarios.
+Note that all requests except (5) and (8) use the same time: `2025-02-20T13:00:00-0500` (EST timezone offset).
 
 1. `Alice` watches `Buddies` -- this is allowed per rule `subscriber-content-access/show`: `Alice` is a `Subscriber` so she can watch any
 `Show` as long as it does not require *Early Access*.
 2. `Bob` watches `The Godparent` -- this is allowed per rule `free-content-access`: `Bob` is a `FreeMember` and `The Godparent` is free content.
 3. `Bob` watches `The Gleaming` -- this is denied because ``free-content-access` is not satisfied: : `Bob` is a `FreeMember` but `The Gleaming` cannot be watched for free.
 4. `Alice` rents `Devilish` -- this is allowed per rule `rent-buy-oscar-movie`: `Alice` is a `Subscriber` and wants to rent the Oscar-nominated musical about 11 days before the Oscars.
-5. `Charlie` watches `Breach` -- this is allowed per rule `early-access-show`: `Charlie` is a `Subscriber` on the `premium` tier so he can watch `Breach` through *Early Access*.
-5. `Dave` watches `Buddies` at`22:00` -- this is not allowed per rule `forbid-bedtime-watch-kid-profile`: `Dave`'s account has the kid profile enabled and it is past bedtime.
+5. `Dave` watches `Breach` after release date -- this is allowed per rule `subscriber-content-access/show`: `Dave` is a `Subscriber` on the `standard` tier and the date is `2025-02-22` (i.e., after the release date) so he can watch the show.
+6. `Alice` watches `Breach` -- this is not allowed: `Alice` is a `Subscriber` on the `standard` tier so she cannot watch `Breach` through *Early Access*.
+7. `Charlie` watches `Breach` -- this is allowed per rule `early-access-show`: `Charlie` is a `Subscriber` on the `premium` tier so he can watch `Breach` through *Early Access*.
+8. `Dave` watches `Buddies` at `22:00` -- this is not allowed per rule `forbid-bedtime-watch-kid-profile`: `Dave`'s account has the kid profile enabled and it is past bedtime.

--- a/cedar-example-use-cases/streaming_service/policies.cedar
+++ b/cedar-example-use-cases/streaming_service/policies.cedar
@@ -5,7 +5,8 @@ permit (
   action == Action::"watch",
   resource is Show
 )
-unless { resource.isEarlyAccess };
+unless
+{ resource.isEarlyAccess && context.now.datetime < resource.releaseDate };
 
 // Subscriber Content Access (Movies)
 @id("subscriber-content-access/movie")
@@ -23,7 +24,7 @@ permit (
   action == Action::"watch",
   resource
 )
-when { resource.isFree == true };
+when { resource.isFree };
 
 // Promo: Rent/Buy Oscar-Nominated Movies Until the Oscars
 @id("rent-buy-oscar-movie")
@@ -35,8 +36,8 @@ permit (
 when
 {
   resource.isOscarNominated &&
-  context.now.timestamp >= datetime("2025-02-02T19:00:00-0500") &&
-  context.now.timestamp < datetime(
+  context.now.datetime >= datetime("2025-02-02T19:00:00-0500") &&
+  context.now.datetime < datetime(
       "2025-03-02T19:00:00-0500"
     ) // Oscars Night
 };
@@ -52,8 +53,7 @@ when
 {
   resource.isEarlyAccess &&
   principal.subscription.tier == "premium" &&
-  context.now.timestamp >= resource.releaseDate.offset(duration("-24h")) &&
-  context.now.timestamp < resource.releaseDate
+  context.now.datetime >= resource.releaseDate.offset(duration("-24h"))
 };
 
 // Forbid Bedtime Access to Kid Profile
@@ -63,12 +63,12 @@ forbid (
   action == Action::"watch",
   resource
 )
-when
+when { principal.profile.isKid }
+unless
 {
   // `toTime()` returns the duration modulo one day (i.e., it ignores the "date"
   // component). Here, we use it to calculate the current time and compare the
   // result against durations that represent 6:00AM and 9:00PM.
-  principal.profile.isKid &&
-  (context.now.timestamp.toTime() >= duration("21h") ||
-   context.now.timestamp.toTime() < duration("6h"))
+  duration("6h") <= context.now.datetime.toTime() &&
+  context.now.datetime.toTime() <= duration("21h")
 };

--- a/cedar-example-use-cases/streaming_service/policies.cedarschema
+++ b/cedar-example-use-cases/streaming_service/policies.cedarschema
@@ -30,7 +30,7 @@ action watch
     resource: [Movie, Show],
     context: {
       now: {
-        timestamp: datetime
+        datetime: datetime
       }
     }
   };
@@ -42,7 +42,7 @@ action rent, buy
     resource: Movie,
     context: {
       now: {
-        timestamp: datetime
+        datetime: datetime
       }
     }
   };


### PR DESCRIPTION
*Description of changes:* Updates the streaming service example with a few fixes/improvements:
 * Extends the general access rule for shows with a check on the date. This effectively fixes a bug where a `standard` tier user would get the default deny when watching an early access show because no rules would apply.
 * Improves the readability of conditions in a few rules.
 * Replaces `timestamp` with `datetime` to prevent readers from assuming it's a string type.
 * Adds two more scenarios and updates the `README.md` file accordingly.


