### PR TITLE
Update OOPSLA24 benchmarks

### DIFF
--- a/oopsla2024-benchmarks/src/apps.rs
+++ b/oopsla2024-benchmarks/src/apps.rs
@@ -245,7 +245,6 @@ impl ExampleApp {
             enable_action_groups_and_attrs: true,
             enable_arbitrary_func_call: false,
             enable_unknowns: false,
-            enable_unspecified_apply_spec: false,
             enable_action_in_constraints: false,
         };
         #[allow(deprecated)]

--- a/oopsla2024-benchmarks/src/tinytodo_generator/common.rs
+++ b/oopsla2024-benchmarks/src/tinytodo_generator/common.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use arbitrary::Unstructured;
 use serde::Serialize;
@@ -18,7 +18,9 @@ impl Entity {
         cedar_policy_core::ast::Entity::new_with_attr_partial_value(
             self.euid.to_euid(),
             HashMap::new(),
+            HashSet::new(),
             self.parents.iter().map(|uid| uid.to_euid()).collect(),
+            BTreeMap::new()
         )
     }
 

--- a/oopsla2024-benchmarks/src/tinytodo_generator/entities.rs
+++ b/oopsla2024-benchmarks/src/tinytodo_generator/entities.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet, BTreeMap};
 
 use arbitrary::{Arbitrary, Unstructured};
 use lazy_static::lazy_static;
@@ -25,52 +25,72 @@ lazy_static! {
         cedar_policy_core::ast::Entity::new_with_attr_partial_value(
             r#"Action::"CreateList""#.parse().unwrap(),
             HashMap::new(),
-            Default::default()
+            HashSet::new(),
+            HashSet::new(),
+            BTreeMap::default()
         ),
         cedar_policy_core::ast::Entity::new_with_attr_partial_value(
             r#"Action::"GetLists""#.parse().unwrap(),
             HashMap::new(),
-            Default::default()
+            HashSet::new(),
+            HashSet::new(),
+            BTreeMap::default()
         ),
         cedar_policy_core::ast::Entity::new_with_attr_partial_value(
             r#"Action::"GetList""#.parse().unwrap(),
             HashMap::new(),
-            Default::default()
+            HashSet::new(),
+            HashSet::new(),
+            BTreeMap::default()
         ),
         cedar_policy_core::ast::Entity::new_with_attr_partial_value(
             r#"Action::"UpdateList""#.parse().unwrap(),
             HashMap::new(),
-            Default::default()
+            HashSet::new(),
+            HashSet::new(),
+            BTreeMap::default()
         ),
         cedar_policy_core::ast::Entity::new_with_attr_partial_value(
             r#"Action::"DeleteList""#.parse().unwrap(),
             HashMap::new(),
-            Default::default()
+            HashSet::new(),
+            HashSet::new(),
+            BTreeMap::default()
         ),
         cedar_policy_core::ast::Entity::new_with_attr_partial_value(
             r#"Action::"CreateTask""#.parse().unwrap(),
             HashMap::new(),
-            Default::default()
+            HashSet::new(),
+            HashSet::new(),
+            BTreeMap::default()
         ),
         cedar_policy_core::ast::Entity::new_with_attr_partial_value(
             r#"Action::"UpdateTask""#.parse().unwrap(),
             HashMap::new(),
-            Default::default()
+            HashSet::new(),
+            HashSet::new(),
+            BTreeMap::default()
         ),
         cedar_policy_core::ast::Entity::new_with_attr_partial_value(
             r#"Action::"DeleteTask""#.parse().unwrap(),
             HashMap::new(),
-            Default::default()
+            HashSet::new(),
+            HashSet::new(),
+            BTreeMap::default()
         ),
         cedar_policy_core::ast::Entity::new_with_attr_partial_value(
             r#"Action::"EditShares""#.parse().unwrap(),
             HashMap::new(),
-            Default::default()
+            HashSet::new(),
+            HashSet::new(),
+            BTreeMap::default()
         ),
         cedar_policy_core::ast::Entity::new_with_attr_partial_value(
             r#"Application::"TinyTodo""#.parse().unwrap(),
             HashMap::new(),
-            Default::default()
+            HashSet::new(),
+            HashSet::new(),
+            BTreeMap::default()
         ),
     ];
 }

--- a/oopsla2024-benchmarks/src/tinytodo_generator/list.rs
+++ b/oopsla2024-benchmarks/src/tinytodo_generator/list.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use arbitrary::{Arbitrary, Unstructured};
 use cedar_policy_core::ast::{EntityUID, PartialValue, Value};
@@ -45,7 +45,9 @@ impl List {
         cedar_policy_core::ast::Entity::new_with_attr_partial_value(
             self.euid.to_euid(),
             attrs,
-            HashSet::default(),
+            HashSet::new(),
+            HashSet::new(),
+            BTreeMap::new()
         )
     }
 


### PR DESCRIPTION
*Description of changes:* The OOPSLA24 benchmarks workflow (running Docker) has been failing for some time now because the code is outdated (see this [CI run](https://github.com/cedar-policy/cedar-examples/actions/runs/14251283834/job/39944409262) for example). This PR makes the adjustments necessary to avoid the failures.

Note: I assume the `parents` field in the `tinytodo_generator` example refers to direct ancestors. Otherwise, we'd need to split `parents` into direct and indirect ancestors to conform with changes in https://github.com/cedar-policy/cedar/pull/1453. Please let me know if that's the case.




