### PR TITLE
Use local time in streaming service example

### DIFF
--- a/cedar-example-use-cases/streaming_service/ALLOW/alice_watch_show.json
+++ b/cedar-example-use-cases/streaming_service/ALLOW/alice_watch_show.json
@@ -7,6 +7,10 @@
             "datetime" : {
                 "fn": "datetime",
                 "arg": "2025-02-20T13:00:00-0500"
+            },
+            "localTimezoneOffset" : {
+                "fn": "duration",
+                "arg": "-5h"
             }
         }
     }

--- a/cedar-example-use-cases/streaming_service/ALLOW/alice_watch_show.json
+++ b/cedar-example-use-cases/streaming_service/ALLOW/alice_watch_show.json
@@ -8,7 +8,7 @@
                 "fn": "datetime",
                 "arg": "2025-02-20T13:00:00-0500"
             },
-            "localTimezoneOffset" : {
+            "localTimeOffset" : {
                 "fn": "duration",
                 "arg": "-5h"
             }

--- a/cedar-example-use-cases/streaming_service/ALLOW/bob_watch_free_movie.json
+++ b/cedar-example-use-cases/streaming_service/ALLOW/bob_watch_free_movie.json
@@ -7,6 +7,10 @@
             "datetime" : {
                 "fn": "datetime",
                 "arg": "2025-02-20T13:00:00-0500"
+            },
+            "localTimezoneOffset" : {
+                "fn": "duration",
+                "arg": "-5h"
             }
         }
     }

--- a/cedar-example-use-cases/streaming_service/ALLOW/bob_watch_free_movie.json
+++ b/cedar-example-use-cases/streaming_service/ALLOW/bob_watch_free_movie.json
@@ -8,7 +8,7 @@
                 "fn": "datetime",
                 "arg": "2025-02-20T13:00:00-0500"
             },
-            "localTimezoneOffset" : {
+            "localTimeOffset" : {
                 "fn": "duration",
                 "arg": "-5h"
             }

--- a/cedar-example-use-cases/streaming_service/ALLOW/charlie_watch_early_access_show.json
+++ b/cedar-example-use-cases/streaming_service/ALLOW/charlie_watch_early_access_show.json
@@ -7,6 +7,10 @@
             "datetime" : {
                 "fn": "datetime",
                 "arg": "2025-02-20T13:00:00-0500"
+            },
+            "localTimezoneOffset" : {
+                "fn": "duration",
+                "arg": "-5h"
             }
         }
     }

--- a/cedar-example-use-cases/streaming_service/ALLOW/charlie_watch_early_access_show.json
+++ b/cedar-example-use-cases/streaming_service/ALLOW/charlie_watch_early_access_show.json
@@ -8,7 +8,7 @@
                 "fn": "datetime",
                 "arg": "2025-02-20T13:00:00-0500"
             },
-            "localTimezoneOffset" : {
+            "localTimeOffset" : {
                 "fn": "duration",
                 "arg": "-5h"
             }

--- a/cedar-example-use-cases/streaming_service/ALLOW/dave_watch_after_early_access.json
+++ b/cedar-example-use-cases/streaming_service/ALLOW/dave_watch_after_early_access.json
@@ -7,6 +7,10 @@
             "datetime" : {
                 "fn": "datetime",
                 "arg": "2025-02-22T13:00:00-0500"
+            },
+            "localTimezoneOffset" : {
+                "fn": "duration",
+                "arg": "-5h"
             }
         }
     }

--- a/cedar-example-use-cases/streaming_service/ALLOW/dave_watch_after_early_access.json
+++ b/cedar-example-use-cases/streaming_service/ALLOW/dave_watch_after_early_access.json
@@ -8,7 +8,7 @@
                 "fn": "datetime",
                 "arg": "2025-02-22T13:00:00-0500"
             },
-            "localTimezoneOffset" : {
+            "localTimeOffset" : {
                 "fn": "duration",
                 "arg": "-5h"
             }

--- a/cedar-example-use-cases/streaming_service/DENY/alice_watch_early_access_show.json
+++ b/cedar-example-use-cases/streaming_service/DENY/alice_watch_early_access_show.json
@@ -7,6 +7,10 @@
             "datetime" : {
                 "fn": "datetime",
                 "arg": "2025-02-20T13:00:00-0500"
+            },
+            "localTimezoneOffset" : {
+                "fn": "duration",
+                "arg": "-5h"
             }
         }
     }

--- a/cedar-example-use-cases/streaming_service/DENY/alice_watch_early_access_show.json
+++ b/cedar-example-use-cases/streaming_service/DENY/alice_watch_early_access_show.json
@@ -8,7 +8,7 @@
                 "fn": "datetime",
                 "arg": "2025-02-20T13:00:00-0500"
             },
-            "localTimezoneOffset" : {
+            "localTimeOffset" : {
                 "fn": "duration",
                 "arg": "-5h"
             }

--- a/cedar-example-use-cases/streaming_service/DENY/bob_watch_paid_movie.json
+++ b/cedar-example-use-cases/streaming_service/DENY/bob_watch_paid_movie.json
@@ -7,6 +7,10 @@
             "datetime" : {
                 "fn": "datetime",
                 "arg": "2025-02-20T13:00:00-0500"
+            },
+            "localTimezoneOffset" : {
+                "fn": "duration",
+                "arg": "-5h"
             }
         }
     }

--- a/cedar-example-use-cases/streaming_service/DENY/bob_watch_paid_movie.json
+++ b/cedar-example-use-cases/streaming_service/DENY/bob_watch_paid_movie.json
@@ -8,7 +8,7 @@
                 "fn": "datetime",
                 "arg": "2025-02-20T13:00:00-0500"
             },
-            "localTimezoneOffset" : {
+            "localTimeOffset" : {
                 "fn": "duration",
                 "arg": "-5h"
             }

--- a/cedar-example-use-cases/streaming_service/DENY/dave_watch_bedtime_show.json
+++ b/cedar-example-use-cases/streaming_service/DENY/dave_watch_bedtime_show.json
@@ -8,7 +8,7 @@
                 "fn": "datetime",
                 "arg": "2025-02-20T22:00:00-0500"
             },
-            "localTimezoneOffset" : {
+            "localTimeOffset" : {
                 "fn": "duration",
                 "arg": "-5h"
             }

--- a/cedar-example-use-cases/streaming_service/DENY/dave_watch_bedtime_show.json
+++ b/cedar-example-use-cases/streaming_service/DENY/dave_watch_bedtime_show.json
@@ -6,7 +6,11 @@
         "now": {
             "datetime" : {
                 "fn": "datetime",
-                "arg": "2025-02-20T22:00:00Z"
+                "arg": "2025-02-20T22:00:00-0500"
+            },
+            "localTimezoneOffset" : {
+                "fn": "duration",
+                "arg": "-5h"
             }
         }
     }

--- a/cedar-example-use-cases/streaming_service/policies.cedar
+++ b/cedar-example-use-cases/streaming_service/policies.cedar
@@ -73,18 +73,12 @@ unless
     .datetime
     .offset
     (
-      context.now.localTimezoneOffset
+      context.now.localTimeOffset
     )
     .toTime
     (
     ) &&
-  context.now
-    .datetime
-    .offset
-    (
-      context.now.localTimezoneOffset
+  context.now.datetime.offset(context.now.localTimeOffset).toTime() <= duration(
+      "21h"
     )
-    .toTime
-    (
-    ) <= duration("21h")
 };

--- a/cedar-example-use-cases/streaming_service/policies.cedar
+++ b/cedar-example-use-cases/streaming_service/policies.cedar
@@ -67,8 +67,8 @@ when { principal.profile.isKid }
 unless
 {
   // `toTime()` returns the duration modulo one day (i.e., it ignores the "date"
-  // component). Here, we use it to calculate the current time and compare the
-  // result against durations that represent 6:00AM and 9:00PM.
+  // component). Here, we use it to calculate the subscriber's local time and
+  // compare the result against durations that represent 6:00AM and 9:00PM.
   duration("6h") <= context.now
     .datetime
     .offset

--- a/cedar-example-use-cases/streaming_service/policies.cedar
+++ b/cedar-example-use-cases/streaming_service/policies.cedar
@@ -69,6 +69,22 @@ unless
   // `toTime()` returns the duration modulo one day (i.e., it ignores the "date"
   // component). Here, we use it to calculate the current time and compare the
   // result against durations that represent 6:00AM and 9:00PM.
-  duration("6h") <= context.now.datetime.toTime() &&
-  context.now.datetime.toTime() <= duration("21h")
+  duration("6h") <= context.now
+    .datetime
+    .offset
+    (
+      context.now.localTimezoneOffset
+    )
+    .toTime
+    (
+    ) &&
+  context.now
+    .datetime
+    .offset
+    (
+      context.now.localTimezoneOffset
+    )
+    .toTime
+    (
+    ) <= duration("21h")
 };

--- a/cedar-example-use-cases/streaming_service/policies.cedarschema
+++ b/cedar-example-use-cases/streaming_service/policies.cedarschema
@@ -30,7 +30,8 @@ action watch
     resource: [Movie, Show],
     context: {
       now: {
-        datetime: datetime
+        datetime: datetime,
+        localTimezoneOffset: duration
       }
     }
   };

--- a/cedar-example-use-cases/streaming_service/policies.cedarschema
+++ b/cedar-example-use-cases/streaming_service/policies.cedarschema
@@ -31,7 +31,7 @@ action watch
     context: {
       now: {
         datetime: datetime,
-        localTimezoneOffset: duration
+        localTimeOffset: duration
       }
     }
   };


### PR DESCRIPTION
*Description of changes:* Add the `localTimeOffset` attribute (of `duration` type) to `context.now` and use it in the last rule of the streaming service example to work with the local time instead of assuming UTC time.

### Callouts
 * The rule has been auto-formatted but doesn't look great to me. If anyone has suggestions to work around it or somehow make it expect another result, please let me know.
 * Happy to move/rename the attribute `localTimeOffset` if you think we should.


