### PR TITLE
Update schema formatting for cedar#1587

### DIFF
--- a/cedar-wasm-example/__tests__/main.test.ts
+++ b/cedar-wasm-example/__tests__/main.test.ts
@@ -400,8 +400,8 @@ describe('json schema functionality', () => {
         if (jsonToSchemaResult.type !== 'success') {
             throw new Error(`Expected success in conversion, got ${JSON.stringify(jsonToSchemaResult, null, 4)}`);
         }
-        expect(jsonToSchemaResult.text.includes(`entity User = {\"name\": __cedar::String};`)).toBe(true);
-        expect(jsonToSchemaResult.text.includes(`action \"sendMessage\" appliesTo {\n  principal: [User],\n  resource: [User],\n  context: {}\n};`)).toBe(true);
+        expect(jsonToSchemaResult.text.includes(`  entity User = {\n    \"name\": __cedar::String\n  };`)).toBe(true);
+        expect(jsonToSchemaResult.text.includes(`  action \"sendMessage\" appliesTo {\n    principal: [User],\n    resource: [User],\n    context: {}\n  };`)).toBe(true);
     });
 });
 


### PR DESCRIPTION
*Description of changes:*

Update schema formatting for https://github.com/cedar-policy/cedar/pull/1587

As a (developer experience) side-note, it took me a while to find that the Github Action in the main repo actually references this repo, I tried finding these tests for a while.

While we're at it here, we could also change the two asserts into one, and use a multi-line string, which would also contain the full schema as formatted now:

```
namespace App {
  entity User = {
    "name": __cedar::String
  };
    
  action "sendMessage" appliesTo {
    principal: [User],
    resource: [User],
    context: {}
  };
}
```