### PR TITLE
Updates dockerfile and prompt to fix issues with Cedar Analysis MCP example.

### DIFF
--- a/cedar-analysis-mcp-server/Dockerfile
+++ b/cedar-analysis-mcp-server/Dockerfile
@@ -34,6 +34,10 @@ ENV CEDAR_SPEC_ROOT=/opt/src/cedar-deps
 WORKDIR $CEDAR_SPEC_ROOT
 RUN git clone --depth 1 https://github.com/cedar-policy/cedar-spec
 
+# Clone `cedar` repositories
+WORKDIR $CEDAR_SPEC_ROOT/cedar-spec/
+RUN git clone --depth 1 https://github.com/cedar-policy/cedar
+
 # Build CLI and Lean library
 WORKDIR $CEDAR_SPEC_ROOT/cedar-spec/
 RUN source /root/.profile \

--- a/cedar-analysis-mcp-server/mcp/src/prompts.ts
+++ b/cedar-analysis-mcp-server/mcp/src/prompts.ts
@@ -176,6 +176,4 @@ export function registerAllPrompts(server: McpServer): void {
       };
     }
   );
-  
-  console.log("Registered prompt: add-and-verify-new-policy-workflow");
 }


### PR DESCRIPTION
* The dockerfile in `cedar-analysis-mcp-server` was broken and would not build because `cedar` was not cloned into the Docker image.

Removes `console.log` statement in `cedar-analysis-mcp-server/mcp/src/prompts.ts` as it violates the MCP protocol's expectations.
